### PR TITLE
育児記録の登録・表示機能

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -22,12 +22,11 @@ class ChildrenController < ApplicationController
   def create
     @child = current_user.children.build(child_params)
     if @child.save
-      redirect_to child_path(@child), notice: '子どもを登録しました'
+      redirect_to root_path, notice: '子どもを登録しました'
     else
       render :new
     end
   end
-
   private
 
   def child_params

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,8 @@
 class HomesController < ApplicationController
   def index
-    @children = current_user.children.includes(:routines, :records)
+    @children = current_user.children.includes(:records)
+    @records = @children.first&.records&.order(recorded_at: :desc) || []
+    @next_task = "ミルク"
   
     # 仮データを用意（ダミー表示用）
     @routine = [

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,11 +1,26 @@
 class HomesController < ApplicationController
   def index
     @children = current_user.children.includes(:records)
-    @records = @children.first&.records&.order(recorded_at: :desc) || []
+    
+    # 安全にパースし、無効な日付でも落ちないようにする
+    @selected_date =
+      begin
+        params[:date].present? ? Date.parse(params[:date]) : Date.current
+      rescue ArgumentError
+        Date.current
+      end
+
+    @records =
+      if @children.first.present?
+        @children.first.records.where(recorded_at: @selected_date.all_day).order(recorded_at: :desc)
+      else
+        []
+      end
+
     @record = Record.new
     @next_task = "ミルク"
-  
-    # 仮データを用意（ダミー表示用）
+
+    # 仮のルーティン（子ども未登録時用ダミー）
     @routine = [
       { time: "08:00", task: "ミルク" },
       { time: "09:00", task: "睡眠" },

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -2,6 +2,7 @@ class HomesController < ApplicationController
   def index
     @children = current_user.children.includes(:records)
     @records = @children.first&.records&.order(recorded_at: :desc) || []
+    @record = Record.new
     @next_task = "ミルク"
   
     # 仮データを用意（ダミー表示用）

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -4,11 +4,15 @@ class RecordsController < ApplicationController
   before_action :set_child
 
   def create
+    @child = Child.find(params[:child_id])
     @record = @child.records.build(record_params)
+  
     if @record.save
       redirect_to root_path, notice: "記録が追加されました"
     else
-      redirect_to root_path, alert: "記録に失敗しました"
+      @children = current_user.children
+      @records = @child.records.where(recorded_at: Time.zone.today.all_day)
+      render "homes/index"  # ←ここでrenderを使うのがポイント！
     end
   end
 

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,0 +1,24 @@
+# app/controllers/records_controller.rb
+class RecordsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_child
+
+  def create
+    @record = @child.records.build(record_params)
+    if @record.save
+      redirect_to root_path, notice: "記録が追加されました"
+    else
+      redirect_to root_path, alert: "記録に失敗しました"
+    end
+  end
+
+  private
+
+  def set_child
+    @child = current_user.children.find(params[:child_id])
+  end
+
+  def record_params
+    params.require(:record).permit(:record_type, :category, :quantity, :recorded_at, :memo)
+  end
+end

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -1,0 +1,2 @@
+module RecordsHelper
+end

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -1,2 +1,10 @@
 module RecordsHelper
+  def icon_for(record_type)
+    {
+      "milk" => "🍼", "breast_milk" => "🤱", "baby_food" => "🍚", "water" => "💧",
+      "sleep" => "🛌", "nap" => "😴", "toilet" => "💩", "temperature" => "🌡️",
+      "medicine" => "💊", "hospital" => "🏥", "bath" => "🛁", "outing" => "🚶‍♀️",
+      "event" => "🎉", "concern" => "😣"
+    }[record_type]
+  end
 end

--- a/app/javascript/home.js
+++ b/app/javascript/home.js
@@ -40,3 +40,10 @@ window.toggleForm = function(childId) {
     form.style.display = "none";
   }
 };
+document.addEventListener("DOMContentLoaded", () => {
+  const errorAlert = document.querySelector("#recordModal .alert-danger");
+  if (errorAlert) {
+    const recordModal = new bootstrap.Modal(document.getElementById("recordModal"));
+    recordModal.show();
+  }
+});

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -2,7 +2,8 @@
 class Child < ApplicationRecord
   belongs_to :user
   has_many :routines, dependent: :destroy
-
+  has_many :records, dependent: :destroy
+  
   validates :name, presence: true
   validates :birth_date, presence: true
   validates :gender, presence: true

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -24,7 +24,7 @@ class Record < ApplicationRecord
     health: "健康",
     medical: "医療",
     schedule: "スケジュール",
-    concern: "気になること"
+    concern_note: "気になること"
   }
 
   validates :record_type, :recorded_at, :category, presence: true

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -28,4 +28,5 @@ class Record < ApplicationRecord
   }
 
   validates :record_type, :recorded_at, :category, presence: true
+  validates :quantity, numericality: { only_integer: true, greater_than: 0 }
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,8 +1,31 @@
 class Record < ApplicationRecord
   belongs_to :child
-  
-  def record_type_i18n
-    { "milk" => "ミルク", "sleep" => "睡眠", "diaper" => "排泄" }[self.record_type]
-  end
-end
 
+  enum record_type: {
+    milk: 0,        # 🍼 ミルク
+    breast_milk: 1, # 🤱 母乳
+    baby_food: 2,   # 🍚 離乳食
+    water: 3,       # 💧 水分補給
+    sleep: 4,       # 🛌 睡眠
+    nap: 5,         # 😴 昼寝
+    toilet: 6,      # 💩 排泄
+    temperature: 7, # 🌡️ 体温
+    medicine: 8,    # 💊 服薬
+    hospital: 9,    # 🏥 通院・予防接種
+    bath: 10,       # 🛁 お風呂
+    outing: 11,     # 🚶‍♀️ 外出
+    event: 12,      # 🎉 行事
+    concern: 13     # 😣 気になる様子
+  }
+
+  enum category: {
+    nutrition: "栄養",
+    life: "生活",
+    health: "健康",
+    medical: "医療",
+    schedule: "スケジュール",
+    concern: "気になること"
+  }
+
+  validates :record_type, :recorded_at, :category, presence: true
+end

--- a/app/views/children/show.html.erb
+++ b/app/views/children/show.html.erb
@@ -3,15 +3,17 @@
 <div class="container p-3">
   <h3><%= @child.name %>ちゃんのルーティン</h3>
 
-  <!-- ルーティンタイムライン -->
-  <div class="bg-light rounded p-3 d-flex justify-content-between text-center">
-    <% @routine.each do |item| %>
-      <div>
-        <%= image_tag "#{item[:task]}.png", style: "height: 32px;" %><br>
-        <%= item[:time] %><br><%= item[:task] %>
-      </div>
-    <% end %>
-  </div>
+<!-- ルーティンタイムライン -->
+<div class="bg-light rounded p-3 d-flex justify-content-between text-center">
+  <% task_image = { "ミルク" => "milk", "睡眠" => "sleep", "排泄" => "diaper" } %>
+
+  <% @routine.each do |item| %>
+    <div>
+      <%= image_tag "#{task_image[item[:task]]}.png", style: "height: 32px;" %><br>
+      <%= item[:time] %><br><%= item[:task] %>
+    </div>
+  <% end %>
+</div>
 
   <!-- 今やるべきタスク -->
   <div id="routine-data" data-routine='<%= raw @routine.to_json %>'></div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -29,17 +29,22 @@
       <button class="btn btn-outline-secondary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#editChildModal">⚙ 子ども編集</button>
     </div>
 
-    <!-- 今日の記録 -->
-    <h5 class="fw-bold">今日の記録</h5>
-    <ul class="list-unstyled">
-      <% if @records.present? %>
-        <% @records.each do |record| %>
-          <li><%= record.recorded_at.strftime("%H:%M") %>　<%= record.record_type_i18n %> <%= record.quantity %></li>
-        <% end %>
-      <% else %>
-        <p class="text-muted">記録はまだありません</p>
-      <% end %>
-    </ul>
+<!-- 今日の記録 -->
+<h5 class="fw-bold">今日の記録</h5>
+<ul class="list-unstyled">
+  <% if @records.present? %>
+    <% @records.each do |record| %>
+      <li>
+        <%= record.recorded_at.strftime("%H:%M") %>　
+        <%= I18n.t("activerecord.attributes.record.record_type.#{record.record_type}") %>
+        （<%= I18n.t("activerecord.attributes.record.category.#{record.category}") %>）
+        <%= record.quantity %>
+      </li>
+    <% end %>
+  <% else %>
+    <p class="text-muted">記録はまだありません</p>
+  <% end %>
+</ul>
 
     <!-- 緊急連絡 -->
     <div class="bg-light rounded p-2 my-3 d-flex align-items-center">
@@ -81,11 +86,23 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
-        <%= form_with(model: Child.new, url: children_path, local: true) do |f| %>
-          <div class="mb-3">
-            <%= f.label :name %>
-            <%= f.text_field :name, class: "form-control" %>
-          </div>
+<%= form_with(model: Child.new, url: children_path, local: true) do |f| %>
+
+  <% if f.object.errors.any? %>
+    <div class="alert alert-danger">
+      <ul class="mb-2">
+        <% f.object.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <!-- この下に入力項目が続く -->
+  <div class="mb-3">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: "form-control" %>
+  </div>
           <div class="mb-3">
             <%= f.label :birth_date %>
             <%= f.date_field :birth_date, class: "form-control" %>
@@ -185,8 +202,16 @@
       </div>
       <div class="modal-body">
         <% if @children.present? %>
-          <%= form_with(model: [@children.first, Record.new], url: child_records_path(@children.first), local: true) do |f| %>
-            <div class="mb-3">
+<%= form_with(model: [@children.first, @record || Record.new], url: child_records_path(@children.first), local: true, data: { turbo: false }) do |f| %>            <div class="mb-3">
+  <% if f.object.errors.any? %>
+  <div class="alert alert-danger">
+    <ul class="mb-2">
+      <% f.object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
               <%= f.label :record_type, "記録の種類" %>
               <%= f.select :record_type, Record.record_types.map { |k, _| [k.humanize, k] }, {}, class: "form-select" %>
             </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,73 +1,76 @@
 <%= javascript_importmap_tags "home" %>
 
-<div class="container p-3" style="max-width: 420px; background-color: #fffefc; border-radius: 20px; border: 1px solid #ddd;">
-
-  <!-- ヘッダー -->
-  <div class="d-flex justify-content-between align-items-center mb-3">
-    <h3 class="fw-bold">BloomNote</h3>
-    <i class="bi bi-list fs-3"></i>
-  </div>
-
-  <h4 class="fw-bold mb-2">ルーティン</h4>
-
-  <!-- ルーティンタイムライン -->
-  <div class="bg-light rounded p-3 d-flex justify-content-between text-center">
-    <div>
-      <%= image_tag "milk.png", style: "height: 32px;" %><br>
-      <strong>ミルク</strong><br>
-      <small>08:00</small>
-    </div>
-    <div>
-      <%= image_tag "sleep.png", style: "height: 32px;" %><br>
-      <strong>睡眠</strong><br>
-      <small>09:00</small>
-    </div>
-    <div>
-      <%= image_tag "diaper.png", style: "height: 32px;" %><br>
-      <strong>排泄</strong><br>
-      <small>11:00</small>
-    </div>
-  </div>
-
-  <!-- 機能ボタン -->
-  <div class="text-center my-3">
-    <button class="btn btn-outline-primary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#childModal">＋ 子ども登録</button>
-    <button class="btn btn-outline-success rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#routineModal">＋ ルーティン追加</button>
-    <button class="btn btn-outline-secondary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#editChildModal">⚙ 子ども編集</button>
-  </div>
-
-  <!-- 今日の記録 -->
-  <h5 class="fw-bold">今日の記録</h5>
-  <ul class="list-unstyled">
-    <% @records&.each do |record| %>
-      <li><%= record.recorded_at.strftime("%H:%M") %>　<%= record.record_type_i18n %> <%= record.quantity %></li>
-    <% end %>
-  </ul>
-
-  <!-- 緊急連絡 -->
-  <div class="bg-light rounded p-2 my-3 d-flex align-items-center">
-    <i class="bi bi-telephone-fill me-2" style="font-size: 1.3rem;"></i>
-    <strong>緊急連絡</strong>
-  </div>
-
-  <!-- アイコン選択 -->
-  <div class="d-flex justify-content-around my-2">
+<% if @children.blank? %>
+  <!-- 子ども未登録の場合のダミー表示 -->
+  <div class="container p-3" style="max-width: 420px; background-color: #fffefc; border-radius: 20px; border: 1px solid #ddd;">
     <div class="text-center">
-      <%= image_tag "milk.png", style: "height: 24px;" %><br>ミルク
-    </div>
-    <div class="text-center">
-      <%= image_tag "sleep.png", style: "height: 24px;" %><br>睡眠
-    </div>
-    <div class="text-center">
-      <%= image_tag "diaper.png", style: "height: 24px;" %><br>排泄
+      <h3 class="fw-bold">BloomNote</h3>
+      <p class="text-muted">まずは子どもを登録してください。</p>
+      <button class="btn btn-primary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#childModal">＋ 子ども登録</button>
     </div>
   </div>
+<% else %>
+  <!-- 子どもが登録されている場合の表示 -->
+  <div class="container p-3" style="max-width: 420px; background-color: #fffefc; border-radius: 20px; border: 1px solid #ddd;">
 
-  <!-- 今やるべきタスク -->
-  <div class="text-center p-2 rounded mt-3 fw-bold" style="background-color: #fff3cd;">
-    今やるべきタスク：<%= @next_task || "未定" %>
+    <!-- ヘッダー -->
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h3 class="fw-bold">BloomNote</h3>
+      <i class="bi bi-list fs-3"></i>
+    </div>
+
+    <h4 class="fw-bold mb-2">ルーティン</h4>
+
+
+    <!-- 機能ボタン -->
+    <div class="text-center my-3">
+      <button class="btn btn-outline-primary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#childModal">＋ 子ども登録</button>
+      <button class="btn btn-outline-success rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#routineModal">＋ ルーティン追加</button>
+      <button class="btn btn-outline-secondary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#editChildModal">⚙ 子ども編集</button>
+    </div>
+
+    <!-- 今日の記録 -->
+    <h5 class="fw-bold">今日の記録</h5>
+    <ul class="list-unstyled">
+      <% if @records.present? %>
+        <% @records.each do |record| %>
+          <li><%= record.recorded_at.strftime("%H:%M") %>　<%= record.record_type_i18n %> <%= record.quantity %></li>
+        <% end %>
+      <% else %>
+        <p class="text-muted">記録はまだありません</p>
+      <% end %>
+    </ul>
+
+    <!-- 緊急連絡 -->
+    <div class="bg-light rounded p-2 my-3 d-flex align-items-center">
+      <i class="bi bi-telephone-fill me-2" style="font-size: 1.3rem;"></i>
+      <strong>緊急連絡</strong>
+    </div>
+
+    <!-- アイコン選択 -->
+    <div class="d-flex justify-content-around my-2">
+      <div class="text-center">
+        <%= image_tag "milk.png", style: "height: 24px;" %><br>ミルク
+      </div>
+      <div class="text-center">
+        <%= image_tag "sleep.png", style: "height: 24px;" %><br>睡眠
+      </div>
+      <div class="text-center">
+        <%= image_tag "diaper.png", style: "height: 24px;" %><br>排泄
+      </div>
+    </div>
+
+    <!-- 今やるべきタスク -->
+    <div class="text-center p-2 rounded mt-3 fw-bold" style="background-color: #fff3cd;">
+      今やるべきタスク：<%= @next_task || "未定" %>
+    </div>
   </div>
-</div>
+<% end %>
+
+<!-- モーダルたちは分岐の外で常に表示可能にする -->
+<%= render "shared/child_modals" %>
+<%= render "shared/routine_modal" %>
+<%= render "shared/record_modal" %>
 
 <!-- 子ども登録モーダル -->
 <div class="modal fade" id="childModal" tabindex="-1" aria-labelledby="childModalLabel" aria-hidden="true">
@@ -197,8 +200,7 @@
             </div>
             <div class="mb-3">
               <%= f.label :recorded_at, "記録日時" %>
-              <%= f.datetime_local_field :recorded_at, Time.current, class: "form-control" %>
-            </div>
+              <%= f.datetime_local_field :recorded_at, value: Time.current.strftime("%Y-%m-%dT%H:%M"), class: "form-control" %>            </div>
             <div class="mb-3">
               <%= f.label :memo, "メモ" %>
               <%= f.text_area :memo, class: "form-control", rows: 2 %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -29,20 +29,72 @@
       <button class="btn btn-outline-secondary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#editChildModal">⚙ 子ども編集</button>
     </div>
 
-<!-- 今日の記録 -->
-<h5 class="fw-bold">今日の記録</h5>
-<ul class="list-unstyled">
-  <% if @records.present? %>
-    <% @records.each do |record| %>
-      <li>
-        <%= record.recorded_at.strftime("%H:%M") %>　
+<!-- 📆 日付切り替えフォーム -->
+<%= form_with url: root_path, method: :get, local: true, class: "mb-3" do %>
+  <div class="d-flex align-items-center">
+    <%= label_tag :date, "表示する日付", class: "me-2 fw-bold" %>
+    <%= date_field_tag :date, @selected_date, class: "form-control w-auto" %>
+    <%= submit_tag "表示", class: "btn btn-outline-primary ms-2" %>
+  </div>
+<% end %>
+
+<!-- 📋 今日の記録一覧 -->
+<h5 class="fw-bold mb-2">
+  記録一覧（<%= @selected_date&.strftime('%Y年%m月%d日') || "日付不明" %>）
+</h5>
+<ul class="list-group">
+  <% @records.each do |record| %>
+    <li class="list-group-item d-flex justify-content-between align-items-start">
+      <div>
+        <strong><%= record.recorded_at.strftime('%H:%M') %></strong>　
+        <%= icon_for(record.record_type) %>
         <%= I18n.t("activerecord.attributes.record.record_type.#{record.record_type}") %>
         （<%= I18n.t("activerecord.attributes.record.category.#{record.category}") %>）
         <%= record.quantity %>
-      </li>
-    <% end %>
-  <% else %>
-    <p class="text-muted">記録はまだありません</p>
+        <% if record.memo.present? %>
+          <span class="text-muted">- <%= record.memo %></span>
+        <% end %>
+      </div>
+      <div>
+        <%= link_to "編集", "#", class: "btn btn-sm btn-outline-secondary", data: { bs_toggle: "modal", bs_target: "#editRecordModal-#{record.id}" } %>
+        <%= button_to "削除", child_record_path(record.child, record), method: :delete,
+              data: { confirm: "本当に削除しますか？" },
+              class: "btn btn-sm btn-outline-danger" %>
+      </div>
+    </li>
+
+    <!-- ✏️ 編集モーダル -->
+    <div class="modal fade" id="editRecordModal-<%= record.id %>" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <%= form_with(model: [record.child, record], local: true) do |f| %>
+            <div class="modal-header">
+              <h5 class="modal-title">記録を編集</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+              <%= f.label :record_type, "記録の種類" %>
+              <%= f.select :record_type, Record.record_types.keys.map { |k| [I18n.t("activerecord.attributes.record.record_type.#{k}"), k] }, {}, class: "form-select mb-2" %>
+
+              <%= f.label :category, "カテゴリ" %>
+              <%= f.select :category, Record.categories.keys.map { |k| [I18n.t("activerecord.attributes.record.category.#{k}"), k] }, {}, class: "form-select mb-2" %>
+
+              <%= f.label :quantity, "量や回数" %>
+              <%= f.number_field :quantity, class: "form-control mb-2" %>
+
+              <%= f.label :recorded_at, "日時" %>
+              <%= f.datetime_local_field :recorded_at, class: "form-control mb-2" %>
+
+              <%= f.label :memo, "メモ" %>
+              <%= f.text_area :memo, class: "form-control", rows: 2 %>
+            </div>
+            <div class="modal-footer">
+              <%= f.submit "更新", class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
   <% end %>
 </ul>
 

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -167,3 +167,50 @@
     </div>
   </div>
 </div>
+<!-- モーダルを開くボタン -->
+<div class="text-center my-3">
+  <button class="btn btn-outline-warning rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#recordModal">＋ 育児記録</button>
+</div>
+
+<!-- 育児記録登録モーダル -->
+<div class="modal fade" id="recordModal" tabindex="-1" aria-labelledby="recordModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="recordModalLabel">育児記録を追加</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <% if @children.present? %>
+          <%= form_with(model: [@children.first, Record.new], url: child_records_path(@children.first), local: true) do |f| %>
+            <div class="mb-3">
+              <%= f.label :record_type, "記録の種類" %>
+              <%= f.select :record_type, Record.record_types.map { |k, _| [k.humanize, k] }, {}, class: "form-select" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :category, "カテゴリ" %>
+              <%= f.select :category, Record.categories.map { |k, v| [v, k] }, {}, class: "form-select" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :quantity, "量や回数" %>
+              <%= f.number_field :quantity, class: "form-control" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :recorded_at, "記録日時" %>
+              <%= f.datetime_local_field :recorded_at, Time.current, class: "form-control" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :memo, "メモ" %>
+              <%= f.text_area :memo, class: "form-control", rows: 2 %>
+            </div>
+            <div class="text-end">
+              <%= f.submit "記録する", class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        <% else %>
+          <p>まず子どもを登録してください。</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,24 +1,26 @@
 <!DOCTYPE html>
 <html>
   <head>
-<title>BloomNote</title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>BloomNote</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<%= csrf_meta_tags %>
-<%= csp_meta_tag %>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
 
-<!-- Bootstrap CSS（CDN）を先に読み込む -->
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
-<!-- 自作のスタイルシート -->
-<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 
-<!-- JavaScript読み込み -->
-<%= javascript_importmap_tags "home" %>
+    <!-- Bootstrap JS（Popper含む）← これが必要！ -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- 自作のCSS -->
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+
+    <!-- JavaScript読み込み -->
+    <%= javascript_importmap_tags "home" %>
   </head>
 
   <body>
-    
     <main>
       <%= yield %>
     </main>

--- a/app/views/shared/_child_modals.html.erb
+++ b/app/views/shared/_child_modals.html.erb
@@ -1,0 +1,28 @@
+<!-- 子ども登録モーダル -->
+<div class="modal fade" id="childModal" tabindex="-1" aria-labelledby="childModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="childModalLabel">子どもを登録</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <%= form_with(model: Child.new, url: children_path, local: true) do |f| %>
+          <div class="mb-3">
+            <%= f.label :name %>
+            <%= f.text_field :name, class: "form-control" %>
+          </div>
+          <div class="mb-3">
+            <%= f.label :birth_date %>
+            <%= f.date_field :birth_date, class: "form-control" %>
+          </div>
+          <div class="mb-3">
+            <%= f.label :gender %>
+            <%= f.select :gender, [["男の子", "boy"], ["女の子", "girl"]], {}, class: "form-select" %>
+          </div>
+          <%= f.submit "登録", class: "btn btn-primary" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_record_modal.html.erb
+++ b/app/views/shared/_record_modal.html.erb
@@ -1,0 +1,40 @@
+<div class="modal fade" id="recordModal" tabindex="-1" aria-labelledby="recordModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="recordModalLabel">育児記録を追加</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <% if @children.present? %>
+          <%= form_with(model: [@children.first, Record.new], url: child_records_path(@children.first), local: true) do |f| %>
+            <div class="mb-3">
+              <%= f.label :record_type, "記録の種類" %>
+              <%= f.select :record_type, Record.record_types.map { |k, _| [k.humanize, k] }, {}, class: "form-select" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :category, "カテゴリ" %>
+              <%= f.select :category, Record.categories.map { |k, v| [v, k] }, {}, class: "form-select" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :quantity, "量や回数" %>
+              <%= f.number_field :quantity, class: "form-control" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :recorded_at, "記録日時" %>
+<%= f.datetime_local_field :recorded_at, value: Time.current.strftime("%Y-%m-%dT%H:%M"), class: "form-control" %>            </div>
+            <div class="mb-3">
+              <%= f.label :memo, "メモ" %>
+              <%= f.text_area :memo, class: "form-control", rows: 2 %>
+            </div>
+            <div class="text-end">
+              <%= f.submit "記録する", class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        <% else %>
+          <p>まず子どもを登録してください。</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_record_modal.html.erb
+++ b/app/views/shared/_record_modal.html.erb
@@ -7,22 +7,36 @@
       </div>
       <div class="modal-body">
         <% if @children.present? %>
-          <%= form_with(model: [@children.first, Record.new], url: child_records_path(@children.first), local: true) do |f| %>
-            <div class="mb-3">
-              <%= f.label :record_type, "記録の種類" %>
-              <%= f.select :record_type, Record.record_types.map { |k, _| [k.humanize, k] }, {}, class: "form-select" %>
-            </div>
-            <div class="mb-3">
-              <%= f.label :category, "カテゴリ" %>
-              <%= f.select :category, Record.categories.map { |k, v| [v, k] }, {}, class: "form-select" %>
-            </div>
+<%= form_with(model: [@children.first, @record || Record.new], url: child_records_path(@children.first), local: true) do |f| %>
+<% if f.object.errors.any? %>
+  <div class="alert alert-danger">
+    <ul class="mb-0">
+      <% f.object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+      <div class="mb-3">
+        <%= f.label :record_type, "記録の種類" %>
+    <%= f.select :record_type,
+      Record.record_types.keys.map { |key| [I18n.t("activerecord.attributes.record.record_type.#{key}"), key] },
+      {}, class: "form-select" %>
+      </div>
+      <div class="mb-3">
+        <%= f.label :category, "カテゴリ" %>
+    <%= f.select :category,
+      Record.categories.keys.map { |key| [I18n.t("activerecord.attributes.record.category.#{key}"), key] },
+      {}, class: "form-select" %>
+      </div>
             <div class="mb-3">
               <%= f.label :quantity, "量や回数" %>
               <%= f.number_field :quantity, class: "form-control" %>
             </div>
             <div class="mb-3">
               <%= f.label :recorded_at, "記録日時" %>
-<%= f.datetime_local_field :recorded_at, value: Time.current.strftime("%Y-%m-%dT%H:%M"), class: "form-control" %>            </div>
+    <%= f.datetime_local_field :recorded_at, value: Time.current.strftime("%Y-%m-%dT%H:%M"), class: "form-control" %>            </div>
             <div class="mb-3">
               <%= f.label :memo, "メモ" %>
               <%= f.text_area :memo, class: "form-control", rows: 2 %>

--- a/app/views/shared/_routine_modal.html.erb
+++ b/app/views/shared/_routine_modal.html.erb
@@ -1,0 +1,35 @@
+<div class="modal fade" id="routineModal" tabindex="-1" aria-labelledby="routineModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="routineModalLabel">ルーティンを追加</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <% if @children.present? %>
+          <%= form_with(model: [@children.first, Routine.new], url: child_routines_path(@children.first), local: true) do |f| %>
+            <div class="mb-3">
+              <%= f.label :time %>
+              <%= f.time_field :time, class: "form-control" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :task %>
+              <%= f.text_field :task, class: "form-control" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :category %>
+              <%= f.select :category, Routine.categories.map { |k,v| [v, k] }, {}, class: "form-select" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :memo %>
+              <%= f.text_area :memo, class: "form-control" %>
+            </div>
+            <%= f.submit "追加", class: "btn btn-success" %>
+          <% end %>
+        <% else %>
+          <p>子どもが登録されていません。</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module BloomNote
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    config.i18n.default_locale = :ja
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,9 +1,9 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
-pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.3.3/dist/js/bootstrap.esm.js"
 pin "home", to: "home.js"
+pin "@hotwired/turbo-rails", to: "turbo.min.js"  

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,26 @@
+ja:
+  activerecord:
+    attributes:
+      record:
+        record_type:
+          milk: "ミルク"
+          breast_milk: "母乳"
+          baby_food: "離乳食"
+          water: "水分補給"
+          sleep: "睡眠"
+          nap: "昼寝"
+          toilet: "排泄"
+          temperature: "体温"
+          medicine: "服薬"
+          hospital: "通院・予防接種"
+          bath: "お風呂"
+          outing: "外出"
+          event: "行事"
+          concern: "気になる様子"
+        category:
+          nutrition: "栄養"
+          life: "生活"
+          health: "健康"
+          medical: "医療"
+          schedule: "スケジュール"
+          concern_note: "気になること"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,7 @@
 ja:
   activerecord:
+    models:
+      record: "育児記録"
     attributes:
       record:
         record_type:
@@ -24,3 +26,13 @@ ja:
           medical: "医療"
           schedule: "スケジュール"
           concern_note: "気になること"
+        quantity: "回数"
+        recorded_at: "記録日時"
+    errors:
+      models:
+        record:
+          attributes:
+            quantity:
+              blank: "を入力してください"
+              not_a_number: "を入力してください"
+              greater_than: "は1以上で入力してください"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :homes 
   resources :children, only: [:new, :create, :index, :show]
   resources :children do
+    resources :routines, only: [:create]
     resources :records, only: [:create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,7 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
   resources :homes 
   resources :children, only: [:new, :create, :index, :show]
+  resources :children do
+    resources :records, only: [:create]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :homes 
   resources :children, only: [:new, :create, :index, :show]
   resources :children do
-    resources :routines, only: [:create]
-    resources :records, only: [:create]
+    resources :records, only: [:create, :update, :destroy]
+    resources :routines
   end
 end

--- a/db/migrate/20250428085605_create_children.rb
+++ b/db/migrate/20250428085605_create_children.rb
@@ -3,7 +3,7 @@ class CreateChildren < ActiveRecord::Migration[7.1]
     create_table :children do |t|
       t.references :user, null: false, foreign_key: true
       t.string :name
-      t.date :birth_data
+      t.date :birth_date
 
       t.timestamps
     end

--- a/db/migrate/20250501020347_add_category_to_records.rb
+++ b/db/migrate/20250501020347_add_category_to_records.rb
@@ -1,0 +1,5 @@
+class AddCategoryToRecords < ActiveRecord::Migration[7.1]
+  def change
+    add_column :records, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_01_020347) do
   create_table "children", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "name"
-    t.date "birth_data"
+    t.date "birth_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "gender", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_30_142125) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_01_020347) do
   create_table "care_relationships", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "parent_id", null: false
     t.bigint "caregiver_id", null: false
@@ -50,6 +50,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_30_142125) do
     t.datetime "recorded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "category"
     t.index ["child_id"], name: "index_records_on_child_id"
   end
 

--- a/spec/helpers/records_helper_spec.rb
+++ b/spec/helpers/records_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the RecordsHelper. For example:
+#
+# describe RecordsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe RecordsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/records_request_spec.rb
+++ b/spec/requests/records_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Records", type: :request do
+
+end


### PR DESCRIPTION
# What
育児記録の登録・表示機能の実装

# Why

育児を任せる親と預かる側の双方が、子どもの日々の状態をリアルタイムで共有できるようにするため。

特に、ミルク・睡眠・排泄などの記録を、その日のうちに簡単に記録＆確認できることで、以下のような課題を解決する目的がある：
	•	「ちゃんとお世話できているか不安」
	•	「どの時間に何をしたのかが把握しづらい」
	•	「育児メモが紙やLINEでバラバラになってしまう」

そのために以下を実装した：
	•	モーダルフォームによる記録登録（UIの手間を最小限に）
	•	登録バリデーションとエラーメッセージ対応（ユーザーのミスを防ぐ）
	•	日付ごとの記録一覧表示（その日の流れが一目でわかる）
	•	編集・削除機能（誤記録を修正可能に）