### PR TITLE
預かり機能のUI・権限制御・表示改善

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,16 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  helper_method :current_child
+
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :role])
+  end
+
+  # 選択中の子どもを返す共通メソッド
+  def current_child
+    @current_child ||= Child.find_by(id: session[:current_child_id])
   end
 end

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -32,14 +32,15 @@ class ChildrenController < ApplicationController
   end
 
   def select
-    child = Child.find(params[:id])
+    child = Child.find_by(id: params[:id])
 
-    if current_user.can_access?(child)
-      session[:current_child_id] = child.id
+    if child && current_user.can_access?(child)
+      session[:selected_child_id] = child.id
       flash[:notice] = "#{child.name} を選択しました"
     else
-      flash[:alert] = "アクセスできません"
+      flash[:alert] = "その子どもにはアクセスできません"
     end
+
     redirect_to root_path
   end
 
@@ -58,6 +59,7 @@ class ChildrenController < ApplicationController
 
   def update
     @child = Child.find(params[:id])
+    redirect_to root_path, alert: '更新権限がありません' and return unless @child
 
     if @child.update(child_params)
       redirect_to root_path, notice: '子ども情報を更新しました'

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -5,22 +5,22 @@ class HomesController < ApplicationController
     @children      = Child.accessible_by(current_user)
     @selected_date = parse_date(params[:date])
     @record        = Record.new
-    @current_child = current_child # 👈 選択された子
-  
+    @current_child = current_child
+
     if @current_child.present?
       @records = @current_child.records
                                .where(recorded_at: @selected_date.all_day)
                                .order(recorded_at: :desc)
-  
+
       @routines = @current_child.routines.order(:time)
-  
+
       current_time = Time.zone.now
       @next_routine = @routines.find do |routine|
         today_time = Time.zone.local(current_time.year, current_time.month, current_time.day,
                                      routine.time.hour, routine.time.min, routine.time.sec)
         today_time > current_time
       end
-  
+
       @next_task_label   = @next_routine&.task_label || "未定"
       @next_routine_time = @next_routine&.time&.strftime("%H:%M")
     else
@@ -30,13 +30,12 @@ class HomesController < ApplicationController
       @next_task_label = "未定"
       @next_routine_time = nil
     end
-  
+
     @care_relationships = current_user.care_relationships.includes(:child, :caregiver)
   end
 
   private
 
-  # params[:date] が不正でも落ちないようにパース
   def parse_date(date_str)
     return Date.current if date_str.blank?
 

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -2,42 +2,35 @@ class HomesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @children      = Child.accessible_by(current_user) # 👈 閲覧可能な子ども全体（親＋共有）
+    @children      = Child.accessible_by(current_user)
     @selected_date = parse_date(params[:date])
     @record        = Record.new
-    @current_child = current_child 
-
-    if (child = @children.first)
-      # 📋 今日の記録一覧（最新順）
-      @records = child.records
-                      .where(recorded_at: @selected_date.all_day)
-                      .order(recorded_at: :desc)
-
-      # 🔁 ルーティン一覧（時刻順）
-      @routines = child.routines.order(:time)
-
-      # ⏰ 今やるべきルーティンを抽出（現在時刻より後、最も近いもの）
+    @current_child = current_child # 👈 選択された子
+  
+    if @current_child.present?
+      @records = @current_child.records
+                               .where(recorded_at: @selected_date.all_day)
+                               .order(recorded_at: :desc)
+  
+      @routines = @current_child.routines.order(:time)
+  
       current_time = Time.zone.now
-
       @next_routine = @routines.find do |routine|
         today_time = Time.zone.local(current_time.year, current_time.month, current_time.day,
                                      routine.time.hour, routine.time.min, routine.time.sec)
         today_time > current_time
       end
-
-      # 💬 表示用プロパティ（補助的に使用する場合）
-      @next_task_label     = @next_routine&.task_label || "未定"
-      @next_routine_time   = @next_routine&.time&.strftime("%H:%M")
+  
+      @next_task_label   = @next_routine&.task_label || "未定"
+      @next_routine_time = @next_routine&.time&.strftime("%H:%M")
     else
-      # 🛑 子ども未登録時の初期化
-      @records             = []
-      @routines            = []
-      @next_routine        = nil
-      @next_task_label     = "未定"
-      @next_routine_time   = nil
+      @records = []
+      @routines = []
+      @next_routine = nil
+      @next_task_label = "未定"
+      @next_routine_time = nil
     end
-
-    # 👩‍👧 保育者リスト（親が追加したもの）
+  
     @care_relationships = current_user.care_relationships.includes(:child, :caregiver)
   end
 

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -2,45 +2,72 @@ class HomesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @children      = Child.accessible_by(current_user)
+    # 子ども一覧（親として or 保育者として預かっている子ども）
+    @children = Child
+                .left_joins(:care_relationships)
+                .where(
+                  "children.user_id = :uid OR care_relationships.caregiver_id = :uid",
+                  uid: current_user.id
+                )
+                .where("care_relationships.status IS NULL OR care_relationships.status = ?", CareRelationship.statuses[:ongoing])
+                .distinct
+
+    # 現在選択中の子ども（セッションから取得 or 一番上の子）
+    @current_child = if session[:selected_child_id]
+                       @children.find_by(id: session[:selected_child_id])
+                     else
+                       @children.first
+                     end
+
+    @is_shared_child = @current_child.present? && @current_child.shared_with?(current_user)
+    # モデルインスタンスの準備（モーダル用）
+    @record    = Record.new
+    @hospital  = Hospital.new
+    @routine   = Routine.new
+    @child     = Child.new
+    @care_relationship = CareRelationship.new
+
+    # CareRelationship一覧（関係者モーダルに使用）
+    @care_relationships =
+      if current_user.role_parent?
+        CareRelationship.includes(:child, :parent, :caregiver)
+                        .where(parent_id: current_user.id)
+      else
+        CareRelationship.includes(:child, :parent, :caregiver)
+                        .where(caregiver_id: current_user.id)
+      end
+
+    # 日付選択
     @selected_date = parse_date(params[:date])
-    @record        = Record.new
-    @current_child = current_child
 
     if @current_child.present?
+      # 育児記録
       @records = @current_child.records
                                .where(recorded_at: @selected_date.all_day)
                                .order(recorded_at: :desc)
 
+      # ルーティン一覧
       @routines = @current_child.routines.order(:time)
 
+      # 今やるべきルーティン（時間が現在より先のものを1件）
       current_time = Time.zone.now
       @next_routine = @routines.find do |routine|
         today_time = Time.zone.local(current_time.year, current_time.month, current_time.day,
                                      routine.time.hour, routine.time.min, routine.time.sec)
         today_time > current_time
       end
-
-      @next_task_label   = @next_routine&.task_label || "未定"
-      @next_routine_time = @next_routine&.time&.strftime("%H:%M")
     else
       @records = []
       @routines = []
       @next_routine = nil
-      @next_task_label = "未定"
-      @next_routine_time = nil
     end
-
-    @care_relationships = current_user.care_relationships.includes(:child, :caregiver)
   end
 
   private
 
-  def parse_date(date_str)
-    return Date.current if date_str.blank?
-
-    Date.parse(date_str)
+  def parse_date(date_param)
+    date_param.present? ? Date.parse(date_param) : Time.zone.today
   rescue ArgumentError
-    Date.current
+    Time.zone.today
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -2,9 +2,10 @@ class HomesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @children      = current_user.children.includes(:records, :routines)
+    @children      = Child.accessible_by(current_user) # 👈 閲覧可能な子ども全体（親＋共有）
     @selected_date = parse_date(params[:date])
     @record        = Record.new
+    @current_child = current_child 
 
     if (child = @children.first)
       # 📋 今日の記録一覧（最新順）

--- a/app/controllers/hospitals_controller.rb
+++ b/app/controllers/hospitals_controller.rb
@@ -5,7 +5,7 @@ class HospitalsController < ApplicationController
 
   def create
     @hospital = current_user.hospitals.build(hospital_params)
-
+    @hospital.user = current_user
     if @hospital.save
       redirect_to root_path, notice: "病院を登録しました"
     else
@@ -32,6 +32,6 @@ class HospitalsController < ApplicationController
   private
 
   def hospital_params
-    params.require(:hospital).permit(:name, :phone_number)
+    params.require(:hospital).permit(:name, :phone_number, :child_id)
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -5,16 +5,18 @@ class RecordsController < ApplicationController
 
   # records_controller.rb
   def create
-    @record = current_user.children.find(params[:child_id]).records.build(record_params)
+    redirect_to root_path, alert: "子どもが選択されていません" and return unless current_child
+  
+    @record = current_child.records.build(record_params.merge(user_id: current_user.id))
     if @record.save
       redirect_to root_path, notice: "記録を追加しました"
     else
-      flash[:record_errors] = @record.errors.full_messages
+      flash[:record_errors]     = @record.errors.full_messages
       flash[:record_attributes] = record_params.to_h
       flash[:record_modal_error] = "true"
       redirect_to root_path
     end
-  end  
+  end
 
   # app/controllers/records_controller.rb
   def update

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,14 +1,13 @@
-# app/controllers/records_controller.rb
 class RecordsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_child
-  before_action :check_caregiver_permissions, only: [:edit, :update, :destroy]
-  
-  # records_controller.rb
+  before_action :check_caregiver_permissions, only: [:update, :destroy]
+
   def create
-    redirect_to root_path, alert: "子どもが選択されていません" and return unless current_child
-  
-    @record = current_child.records.build(record_params.merge(user_id: current_user.id))
+    redirect_to root_path, alert: "子どもが見つかりません" and return unless @child
+
+    @record = @child.records.build(record_params.merge(user_id: current_user.id))
+
     if @record.save
       redirect_to root_path, notice: "記録を追加しました"
     else
@@ -19,20 +18,18 @@ class RecordsController < ApplicationController
     end
   end
 
-  # app/controllers/records_controller.rb
   def update
-    @record = current_user.children.find(params[:child_id]).records.find(params[:id])
+    @record = @child.records.find(params[:id])
     if @record.update(record_params)
       redirect_to root_path, notice: "記録を更新しました"
     else
       flash[:record_errors] = @record.errors.full_messages
-      flash[:open_modal] = "editRecordModal-#{@record.id}"  # ←ここ重要！
+      flash[:open_modal] = "editRecordModal-#{@record.id}"
       redirect_to root_path
     end
   end
 
   def destroy
-    @child = current_user.children.find(params[:child_id])
     @record = @child.records.find(params[:id])
     @record.destroy
     redirect_to root_path, notice: "記録を削除しました"
@@ -41,17 +38,25 @@ class RecordsController < ApplicationController
   private
 
   def set_child
-    @child = current_user.children.find(params[:child_id])
+    @child = Child
+             .left_joins(:care_relationships)
+             .where(id: params[:child_id])
+             .where("children.user_id = :uid OR care_relationships.caregiver_id = :uid", uid: current_user.id)
+             .where("care_relationships.status IS NULL OR care_relationships.status = ?", CareRelationship.statuses[:ongoing])
+             .distinct
+             .first
+  
+    puts "🧪 child found? => #{@child.present?}"
   end
 
   def record_params
     params.require(:record).permit(:record_type, :category, :quantity, :recorded_at, :memo)
   end
-end
 
-def check_caregiver_permissions
-  return unless current_user.caregiver? && @child.shared_with?(current_user)
+  def check_caregiver_permissions
+    return unless current_user.role_caregiver?
 
-  redirect_to root_path, alert: "編集権限がありません"
-  
+    redirect_to root_path, alert: "編集・削除はできません" and return
+    
+  end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -2,7 +2,8 @@
 class RecordsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_child
-
+  before_action :check_caregiver_permissions, only: [:edit, :update, :destroy]
+  
   # records_controller.rb
   def create
     redirect_to root_path, alert: "子どもが選択されていません" and return unless current_child
@@ -46,4 +47,11 @@ class RecordsController < ApplicationController
   def record_params
     params.require(:record).permit(:record_type, :category, :quantity, :recorded_at, :memo)
   end
+end
+
+def check_caregiver_permissions
+  return unless current_user.caregiver? && @child.shared_with?(current_user)
+
+  redirect_to root_path, alert: "編集権限がありません"
+  
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def can_edit_child_content?(child)
+    current_user.parent? || child.shared_with?(current_user)
+  end
 end

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -2,7 +2,7 @@ module RecordsHelper
   def icon_for(record_type)
     {
       "milk" => "🍼", "breast_milk" => "🤱", "baby_food" => "🍚", "water" => "💧",
-      "sleep" => "🛌", "nap" => "😴", "toilet" => "💩", "temperature" => "🌡️",
+      "sleep" => "🛌", "nap" => "😴", "toilet" => "🧻", "temperature" => "🌡️",
       "medicine" => "💊", "hospital" => "🏥", "bath" => "🛁", "outing" => "🚶‍♀️",
       "event" => "🎉", "concern" => "😣"
     }[record_type]

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,4 @@
 // app/javascript/home.js (こちらを使っている場合)
 import "@hotwired/turbo-rails"
 import "bootstrap"
-import "./home"
+import "home"

--- a/app/models/care_relationship.rb
+++ b/app/models/care_relationship.rb
@@ -4,7 +4,9 @@ class CareRelationship < ApplicationRecord
   belongs_to :child
 
   enum status: { ongoing: 0, ended: 1 }
-
+  def status_i18n
+    I18n.t("enums.care_relationship.status.#{status}")
+  end
   validates :parent, presence: { message: "を入力してください" }
   validates :caregiver, presence: { message: "を入力してください" }
   validates :child, presence: { message: "を入力してください" }

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -3,6 +3,7 @@ class Child < ApplicationRecord
   has_many :routines, dependent: :destroy
   has_many :records, dependent: :destroy
   has_many :care_relationships, dependent: :destroy
+  has_many :hospitals, dependent: :destroy # ← ✅ 複数形に修正
 
   validates :name, presence: true
   validates :birth_date, presence: true
@@ -10,12 +11,10 @@ class Child < ApplicationRecord
 
   enum gender: { unspecified: 0, boy: 1, girl: 2 }
 
-  # ✅ この子が指定ユーザーに共有されているか？
   def shared_with?(user)
     care_relationships.exists?(caregiver_id: user.id, status: CareRelationship.statuses[:ongoing])
   end
 
-  # ✅ 閲覧可能な子ども一覧スコープ（親 or 保育者 with ongoing）
   scope :accessible_by, lambda { |user|
     left_joins(:care_relationships)
       .where(

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,12 +1,28 @@
-# app/models/child.rb
 class Child < ApplicationRecord
   belongs_to :user
   has_many :routines, dependent: :destroy
   has_many :records, dependent: :destroy
-  
+  has_many :care_relationships, dependent: :destroy
+
   validates :name, presence: true
   validates :birth_date, presence: true
   validates :gender, presence: true
 
   enum gender: { unspecified: 0, boy: 1, girl: 2 }
+
+  # ✅ この子が指定ユーザーに共有されているか？
+  def shared_with?(user)
+    care_relationships.exists?(caregiver_id: user.id, status: CareRelationship.statuses[:ongoing])
+  end
+
+  # ✅ 閲覧可能な子ども一覧スコープ（親 or 保育者 with ongoing）
+  scope :accessible_by, lambda { |user|
+    left_joins(:care_relationships)
+      .where(
+        "children.user_id = :uid OR (care_relationships.caregiver_id = :uid AND care_relationships.status = :status)",
+        uid: user.id,
+        status: CareRelationship.statuses[:ongoing]
+      )
+      .distinct
+  }
 end

--- a/app/models/hospital.rb
+++ b/app/models/hospital.rb
@@ -1,6 +1,7 @@
 # app/models/hospital.rb
 class Hospital < ApplicationRecord
   belongs_to :user
+  belongs_to :child
 
   validates :name, presence: { message: '緊急連絡名を入力してください' }
   validates :phone_number, presence: { message: '電話番号を入力してください' }

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -9,7 +9,7 @@ class Record < ApplicationRecord
     water: 3,       # 💧 水分補給
     sleep: 4,       # 🛌 睡眠
     nap: 5,         # 😴 昼寝
-    toilet: 6,      # 💩 排泄
+    toilet: 6,      # 🧻 排泄
     temperature: 7, # 🌡️ 体温
     medicine: 8,    # 💊 服薬
     hospital: 9,    # 🏥 通院・予防接種

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,5 +1,6 @@
 class Record < ApplicationRecord
   belongs_to :child
+  belongs_to :user
 
   enum record_type: {
     milk: 0,        # 🍼 ミルク

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,4 +25,14 @@ class User < ApplicationRecord
 
   # enum（ユーザー権限）
   enum role: { role_parent: 0, role_caregiver: 1 }
+  def can_access?(child)
+    return true if child.user_id == id # 親ならアクセス可能
+
+    # 保育者で「共有中」の関係があるか
+    CareRelationship.exists?(
+      child_id: child.id,
+      caregiver_id: id,
+      status: :ongoing
+    )
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   # 子どもと病院
   has_many :children, dependent: :destroy
   has_many :hospitals, dependent: :destroy
-
+  has_many :records
   # 親としてのケアリレーションシップ（親が追加したもの）
   has_many :care_relationships,
            class_name: 'CareRelationship',

--- a/app/views/care_relationships/update.turbo_stream.erb
+++ b/app/views/care_relationships/update.turbo_stream.erb
@@ -1,17 +1,7 @@
-<%= turbo_stream.replace "care_relationship_#{@care_relationship.id}",
-      partial: "shared/care_relationship",
-      locals: { care_relationship: @care_relationship } %>
-
-<%= turbo_stream.replace "flash", partial: "shared/flash" %>
+<%= turbo_stream.replace "care_relationship_#{@care_relationship.id}" do %>
+  <%= render partial: "shared/care_relationship", locals: { care_relationship: @care_relationship } %>
+<% end %>
 
 <%= turbo_stream.replace "flash" do %>
   <%= render "shared/flash" %>
-<% end %>
-
-<%= turbo_stream.replace "care_relationship_#{@care_relationship.id}" do %>
-  <%= render partial: "shared/care_relationship", locals: { care_relationship: @care_relationship } %>
-<% end %>
-
-<%= turbo_stream.replace "care_relationship_#{@care_relationship.id}" do %>
-  <%= render partial: "shared/care_relationship", locals: { care_relationship: @care_relationship } %>
 <% end %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -36,7 +36,7 @@
 <div class="container p-3" style="max-width: 420px; background-color: #fffefc; border-radius: 20px; border: 1px solid #ddd;">
   <!-- 🌟 ヘッダー─共通 -->
   <div class="d-flex justify-content-between align-items-center mb-3">
-    <h3 class="fw-bold">BloomNote</h3>
+   <h3 class="fw-bold"><%= @current_child&.name || "BloomNote" %></h3>
 
 <div class="dropdown">
   <button class="btn" type="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false">

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -37,25 +37,40 @@
   <!-- 🌟 ヘッダー─共通 -->
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h3 class="fw-bold">BloomNote</h3>
-    <div class="dropdown">
-      <button class="btn" type="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false">
-        <i class="bi bi-list fs-3"></i>
-      </button>
-      <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="settingsDropdown">
-        <% if user_signed_in? %>
-          <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addCareRelationshipModal">保育者を追加</button></li>
-          <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#careRelationshipListModal">関係者一覧</button></li>
-          <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#switchStatusModal">ステータス切替</button></li>
-          <li><hr class="dropdown-divider"></li>
+
+<div class="dropdown">
+  <button class="btn" type="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+    <i class="bi bi-list fs-3"></i>
+  </button>
+  <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="settingsDropdown">
+    <% if user_signed_in? %>
+      <!-- 子ども一覧セクション -->
+      <% if @children.present? %>
+        <li class="dropdown-header">子どもを切り替え</li>
+        <% @children.each do |child| %>
           <li>
-            <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: true }, form: { class: "d-inline" }, class: "dropdown-item text-danger" %>
+<%= button_to select_child_path(child), method: :patch, form: { class: "d-inline" }, class: "dropdown-item" do %>
+  <%= child.name %><%= "（預かり中）" if child.shared_with?(current_user) %>
+<% end %>
           </li>
-        <% else %>
-          <li><%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %></li>
-          <li><%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %></li>
         <% end %>
-      </ul>
-    </div>
+        <li><hr class="dropdown-divider"></li>
+      <% end %>
+
+      <!-- 既存項目 -->
+      <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addCareRelationshipModal">保育者を追加</button></li>
+      <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#careRelationshipListModal">関係者一覧</button></li>
+      <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#switchStatusModal">ステータス切替</button></li>
+      <li><hr class="dropdown-divider"></li>
+      <li>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: true }, form: { class: "d-inline" }, class: "dropdown-item text-danger" %>
+      </li>
+    <% else %>
+      <li><%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %></li>
+      <li><%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %></li>
+    <% end %>
+  </ul>
+</div>
   </div>
 
   <% if @children.blank? %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -81,11 +81,14 @@
     </div>
   <% else %>
     <!-- 🟢 子ども登録済み時 -->
-    <div class="text-center my-3">
-      <button class="btn btn-outline-primary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#childModal">＋ 子ども登録</button>
-      <button class="btn btn-outline-success rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#routineModal">＋ ルーティン追加</button>
-      <button class="btn btn-outline-secondary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#editChildModal">⚙ 子ども編集</button>
-    </div>
+<div class="text-center my-3">
+  <button class="btn btn-outline-primary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#childModal">＋ 子ども登録</button>
+  <% if current_user.role_parent? && (@current_child.user_id == current_user.id) %>
+  <button class="btn btn-outline-success rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#routineModal">＋ ルーティン追加</button>
+  <button class="btn btn-outline-secondary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#editChildModal">⚙ 子ども編集</button>
+<% end %>
+  <button class="btn btn-outline-warning rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#recordModal">＋ 育児記録</button>
+</div>
 
     <!-- 📆 日付切替えフォーム -->
     <%= form_with url: root_path, method: :get, local: true, class: "mb-3" do %>
@@ -197,6 +200,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
+
         <h5 class="modal-title" id="editChildModalLabel">子ども情報を編集</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
@@ -296,26 +300,30 @@
       <!-- モーダルヘッダー -->
       <div class="modal-header">
         <h5 class="modal-title" id="emergencyModalLabel">緊急連絡先</h5>
-        <button class="btn btn-sm btn-outline-primary ms-3" data-bs-toggle="modal" data-bs-target="#newHospitalModal">＋病院を追加</button>
+        <% if current_user.id == @current_child.user_id %>
+          <button class="btn btn-sm btn-outline-primary ms-3" data-bs-toggle="modal" data-bs-target="#newHospitalModal">＋病院を追加</button>
+        <% end %>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
 
       <!-- モーダルボディ -->
       <div class="modal-body">
-<% if @current_child&.hospitals&.any? %>
-  <% @current_child.hospitals.each do |hospital| %>
+        <% if @current_child&.hospitals&.any? %>
+          <% @current_child.hospitals.each do |hospital| %>
             <div class="border rounded p-2 mb-3">
               <p>
                 <strong><%= hospital.name %></strong><br>
                 <%= link_to hospital.phone_number, "tel:#{hospital.phone_number}", class: "btn btn-outline-danger btn-sm mt-1" %>
               </p>
-              <!-- 編集ボタン -->
-              <button class="btn btn-sm btn-outline-secondary"
-                      data-bs-dismiss="modal"
-                      data-bs-toggle="modal"
-                      data-bs-target="#editHospitalModal-<%= hospital.id %>">
-                編集
-              </button>
+              <% if current_user.id == @current_child.user_id %>
+                <!-- 編集ボタン（親ユーザーのみ表示） -->
+                <button class="btn btn-sm btn-outline-secondary"
+                        data-bs-dismiss="modal"
+                        data-bs-toggle="modal"
+                        data-bs-target="#editHospitalModal-<%= hospital.id %>">
+                  編集
+                </button>
+              <% end %>
             </div>
           <% end %>
         <% else %>
@@ -380,48 +388,6 @@
   </div>
 <% end %>
 
-<!-- 病院情報 新規追加モーダル -->
-<div class="modal fade" id="newHospitalModal" tabindex="-1" aria-labelledby="newHospitalModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <%= form_with(model: [@current_child, Hospital.new], url: child_hospitals_path(@current_child), local: true) do |f| %>
-        <div class="modal-header">
-          <h5 class="modal-title" id="newHospitalModalLabel">病院を追加</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
-        </div>
-
-        <div class="modal-body">
-          <% if flash[:hospital_errors] %>
-            <div class="alert alert-danger">
-              <ul class="mb-0">
-                <% flash[:hospital_errors].each do |msg| %>
-                  <li><%= msg %></li>
-                <% end %>
-              </ul>
-            </div>
-          <% end %>
-
-          <!-- 🔒 child_id を hidden_field で明示 -->
-          <%= f.hidden_field :child_id, value: @current_child&.id %>
-
-          <div class="mb-3">
-            <%= f.label :name, "病院名" %>
-            <%= f.text_field :name, value: flash[:hospital_attributes]&.[]("name"), class: "form-control", id: "hospital_name" %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :phone_number, "電話番号" %>
-            <%= f.telephone_field :phone_number, value: flash[:hospital_attributes]&.[]("phone_number"), class: "form-control", id: "hospital_phone_number" %>
-          </div>
-        </div>
-
-        <div class="modal-footer">
-          <%= f.submit "追加する", class: "btn btn-primary" %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</div>
 
 <!-- エラー発生時に対象の編集モーダルを自動で開く -->
 <% if flash[:hospital_modal_error] %>
@@ -435,7 +401,7 @@
 <div class="modal fade" id="addCareRelationshipModal" tabindex="-1" aria-labelledby="addCareRelationshipModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-<%= form_with model: CareRelationship.new, url: care_relationships_path, local: true do |f| %>
+<%= form_with model: CareRelationship.new, url: care_relationships_path, local: false do |f| %>
         <div class="modal-header">
           <h5 class="modal-title" id="addCareRelationshipModalLabel">保育者を追加</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -35,8 +35,17 @@
 </div>
 <div class="container p-3" style="max-width: 420px; background-color: #fffefc; border-radius: 20px; border: 1px solid #ddd;">
   <!-- 🌟 ヘッダー─共通 -->
-  <div class="d-flex justify-content-between align-items-center mb-3">
-   <h3 class="fw-bold"><%= @current_child&.name || "BloomNote" %></h3>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h3 class="fw-bold">
+    <% if @current_child.present? %>
+      <%= @current_child.name %>
+      <% if @is_shared_child %>
+        <span class="text-muted fs-6">（預かり中）</span>
+      <% end %>
+    <% else %>
+      BloomNote
+    <% end %>
+  </h3>
 
 <div class="dropdown">
   <button class="btn" type="button" id="settingsDropdown" data-bs-toggle="dropdown" aria-expanded="false">
@@ -60,7 +69,6 @@
       <!-- 既存項目 -->
       <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addCareRelationshipModal">保育者を追加</button></li>
       <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#careRelationshipListModal">関係者一覧</button></li>
-      <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#switchStatusModal">ステータス切替</button></li>
       <li><hr class="dropdown-divider"></li>
       <li>
         <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: true }, form: { class: "d-inline" }, class: "dropdown-item text-danger" %>
@@ -83,7 +91,7 @@
     <!-- 🟢 子ども登録済み時 -->
 <div class="text-center my-3">
   <button class="btn btn-outline-primary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#childModal">＋ 子ども登録</button>
-  <% if current_user.role_parent? && (@current_child.user_id == current_user.id) %>
+<% if current_user.role_parent? && @current_child && (@current_child.user_id == current_user.id) %>
   <button class="btn btn-outline-success rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#routineModal">＋ ルーティン追加</button>
   <button class="btn btn-outline-secondary rounded-pill px-4" data-bs-toggle="modal" data-bs-target="#editChildModal">⚙ 子ども編集</button>
 <% end %>
@@ -107,7 +115,7 @@
 </h5>
 
 <ul class="list-group">
-  <% @records.each do |record| %>
+  <% @records.order(recorded_at: :desc).each do |record| %>
     <li class="list-group-item d-flex justify-content-between align-items-start">
       <div>
         <strong><%= record.recorded_at.strftime('%H:%M') %></strong>　
@@ -117,12 +125,24 @@
         <% if record.memo.present? %>
           <span class="text-muted">- <%= record.memo %></span>
         <% end %>
+        <br>
+<span class="text-muted mt-1">
+  記録者：<%= record.user.nickname %>
+</span>
       </div>
       <div>
-<%= link_to "編集", "#", class: "btn btn-sm btn-outline-secondary", data: { bs_toggle: "modal", bs_target: "#editRecordModal-#{record.id}" } %>
-        <%= button_to "削除", child_record_path(record.child, record), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-sm btn-outline-danger" %>
+        <%= link_to "編集", "#",
+              class: "btn btn-sm btn-outline-secondary",
+              data: { bs_toggle: "modal", bs_target: "#editRecordModal-#{record.id}" } %>
+        <%= button_to "削除",
+              child_record_path(record.child, record),
+              method: :delete,
+              data: { confirm: "本当に削除しますか？" },
+              class: "btn btn-sm btn-outline-danger" %>
       </div>
     </li>
+
+    <!-- 編集モーダル -->
     <div class="modal fade" id="editRecordModal-<%= record.id %>" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog">
         <div class="modal-content">
@@ -132,28 +152,32 @@
               <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
-<% if flash[:open_modal] == "editRecordModal-#{record.id}" && flash[:record_errors] %>
-  <div class="alert alert-danger">
-    <ul class="mb-0">
-      <% flash[:record_errors].each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-<%= f.label :record_type, "記録の種類" %>
-<%= f.select :record_type,
-  Record.record_types.keys.map { |key| [I18n.t("activerecord.attributes.record.record_type.#{key}", default: key), key] },
-  {},
-  class: "form-select mb-2",
-  id: "record_record_type" %>
+              <% if flash[:open_modal] == "editRecordModal-#{record.id}" && flash[:record_errors] %>
+                <div class="alert alert-danger">
+                  <ul class="mb-0">
+                    <% flash[:record_errors].each do |msg| %>
+                      <li><%= msg %></li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
+
+              <%= f.label :record_type, "記録の種類" %>
+              <%= f.select :record_type,
+                    Record.record_types.keys.map { |key| [I18n.t("activerecord.attributes.record.record_type.#{key}"), key] },
+                    {}, class: "form-select mb-2" %>
 
               <%= f.label :category, "カテゴリ" %>
-              <%= f.select :category, Record.categories.keys.map { |k| [I18n.t("activerecord.attributes.record.category.#{k}"), k] }, {}, class: "form-select mb-2" %>
+              <%= f.select :category,
+                    Record.categories.keys.map { |key| [I18n.t("activerecord.attributes.record.category.#{key}"), key] },
+                    {}, class: "form-select mb-2" %>
+
               <%= f.label :quantity, "量や回数" %>
               <%= f.number_field :quantity, class: "form-control mb-2" %>
+
               <%= f.label :recorded_at, "日時" %>
               <%= f.datetime_local_field :recorded_at, class: "form-control mb-2" %>
+
               <%= f.label :memo, "メモ" %>
               <%= f.text_area :memo, class: "form-control", rows: 2 %>
             </div>
@@ -192,7 +216,7 @@
 <%= render "shared/child_modals" %>
 <%= render "shared/routine_modal" %>
 <%= render "shared/record_modal" %>
-
+<%= render "shared/hospital_form_modal" %>
 
 
 <!-- 子ども編集モーダル -->
@@ -200,12 +224,12 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-
         <h5 class="modal-title" id="editChildModalLabel">子ども情報を編集</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
+
       <div class="modal-body">
-        <% if @children.present? %>
+        <% if @current_child.present? %>
           <%= form_with(model: @current_child, url: child_path(@current_child), method: :patch, local: true) do |f| %>
 
             <% if flash[:child_errors] %>
@@ -219,28 +243,36 @@
             <% end %>
 
             <div class="mb-3">
-              <%= f.label :name %>
+              <%= f.label :name, "名前" %>
               <%= f.text_field :name,
                     value: flash[:child_attributes]&.[]("name") || f.object.name,
                     class: "form-control" %>
             </div>
 
             <div class="mb-3">
-              <%= f.label :birth_date %>
+              <%= f.label :birth_date, "生年月日" %>
               <%= f.date_field :birth_date,
                     value: flash[:child_attributes]&.[]("birth_date") || f.object.birth_date,
                     class: "form-control" %>
             </div>
 
             <div class="mb-3">
-              <%= f.label :gender %>
+              <%= f.label :gender, "性別" %>
               <%= f.select :gender,
                     [["男の子", "boy"], ["女の子", "girl"]],
                     { selected: flash[:child_attributes]&.[]("gender") || f.object.gender },
                     class: "form-select" %>
             </div>
 
-            <%= f.submit "更新", class: "btn btn-primary" %>
+            <div class="d-flex justify-content-between">
+              <%= f.submit "更新", class: "btn btn-primary" %>
+
+<%= button_to "削除", child_path(@current_child),
+      method: :delete,
+      data: { turbo: false, confirm: "本当に削除しますか？" },
+      class: "btn btn-danger mt-3" %>
+            </div>
+
           <% end %>
         <% else %>
           <p>編集できる子どもがいません。</p>
@@ -259,9 +291,10 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
-        <% if @children.present? %>
-          <%= form_with(model: [@current_child, Routine.new], url: child_routines_path(@current_child), local: true) do |f| %>
-            <div class="mb-3">
+<% if @current_child.present? %>
+  <%= form_with(model: [@current_child, Routine.new], url: child_routines_path(@current_child), local: true) do |f| %>
+  
+                <div class="mb-3">
               <%= f.label :time %>
               <%= f.time_field :time, class: "form-control" %>
             </div>
@@ -297,11 +330,16 @@
 <div class="modal fade" id="emergencyModal" tabindex="-1" aria-labelledby="emergencyModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-      <!-- モーダルヘッダー -->
       <div class="modal-header">
         <h5 class="modal-title" id="emergencyModalLabel">緊急連絡先</h5>
-        <% if current_user.id == @current_child.user_id %>
-          <button class="btn btn-sm btn-outline-primary ms-3" data-bs-toggle="modal" data-bs-target="#newHospitalModal">＋病院を追加</button>
+       <% if @current_child && current_user.id == @current_child.user_id %>
+<button type="button"
+        class="btn btn-sm btn-outline-primary"
+        data-bs-dismiss="modal"
+        data-bs-toggle="modal"
+        data-bs-target="#newHospitalModal">
+  ＋病院を追加
+</button>
         <% end %>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
@@ -445,65 +483,14 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
 
-      <!-- モーダルボディ -->
-      <div class="modal-body">
-        <% if @care_relationships.present? && @care_relationships.any? %>
-          <table class="table table-hover table-bordered align-middle">
-            <thead class="table-light">
-              <tr>
-                <th>子ども</th>
-                <th>親</th>
-                <th>保育者</th>
-                <th class="text-center">ステータス</th>
-              </tr>
-            </thead>
-            <tbody>
-              <% @care_relationships.each do |rel| %>
-                <tr>
-                  <td><%= rel.child.name %></td>
-                  <td><%= rel.parent.nickname %></td>
-                  <td><%= rel.caregiver.nickname %></td>
-                  <td class="text-center">
-                    <% if rel.ongoing? %>
-                      <span class="badge bg-success">預かり中</span>
-                    <% else %>
-                      <span class="badge bg-secondary">終了</span>
-                    <% end %>
-                      <% if rel.parent == current_user %>
-    <%= button_to "削除", care_relationship_path(rel),
-        method: :delete,
-        data: { turbo_confirm: "本当に削除しますか？" },
-        class: "btn btn-sm btn-outline-danger mt-2" %>
-  <% end %>
-                  </td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        <% else %>
-          <p class="text-muted">関係者が登録されていません。</p>
-        <% end %>
-      </div>
+<div class="modal-body">
+  <% if @care_relationships.present? %>
+    <div class="d-flex flex-column gap-2">
+      <% @care_relationships.each do |care_relationship| %>
+        <%= render "shared/care_relationship", care_relationship: care_relationship %>
+      <% end %>
     </div>
-  </div>
-</div>
-<!-- ステータス切り替えモーダル -->
-<div class="modal fade" id="switchStatusModal" tabindex="-1" aria-labelledby="switchStatusModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="switchStatusModalLabel">保育ステータスを切り替え</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
-      </div>
-      <div class="modal-body">
-<% if defined?(@care_relationships) && @care_relationships.present? %>
-  <% @care_relationships.each do |cr| %>
-    <%= render partial: "shared/care_relationship", locals: { care_relationship: cr } %>          
+  <% else %>
+    <p class="text-muted">関係者が登録されていません。</p>
   <% end %>
-<% else %>
-  <p class="text-muted">関係者情報が取得できませんでした。</p>
-<% end %>
-      </div>
-    </div>
-  </div>
 </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -202,7 +202,7 @@
       </div>
       <div class="modal-body">
         <% if @children.present? %>
-          <%= form_with(model: @children.first, url: child_path(@children.first), method: :patch, local: true) do |f| %>
+          <%= form_with(model: @current_child, url: child_path(@current_child), method: :patch, local: true) do |f| %>
 
             <% if flash[:child_errors] %>
               <div class="alert alert-danger">
@@ -256,7 +256,7 @@
       </div>
       <div class="modal-body">
         <% if @children.present? %>
-          <%= form_with(model: [@children.first, Routine.new], url: child_routines_path(@children.first), local: true) do |f| %>
+          <%= form_with(model: [@current_child, Routine.new], url: child_routines_path(@current_child), local: true) do |f| %>
             <div class="mb-3">
               <%= f.label :time %>
               <%= f.time_field :time, class: "form-control" %>
@@ -302,8 +302,8 @@
 
       <!-- モーダルボディ -->
       <div class="modal-body">
-        <% if current_user.hospitals.any? %>
-          <% current_user.hospitals.each do |hospital| %>
+<% if @current_child&.hospitals&.any? %>
+  <% @current_child.hospitals.each do |hospital| %>
             <div class="border rounded p-2 mb-3">
               <p>
                 <strong><%= hospital.name %></strong><br>
@@ -336,7 +336,7 @@
        aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
-        <%= form_with(model: hospital, url: hospital_path(hospital), method: :patch, local: true) do |f| %>
+<%= form_with(model: [hospital.child, hospital], url: child_hospital_path(hospital.child, hospital), method: :patch, local: true) do |f| %>
         <% if flash[:hospital_errors] && flash[:hospital_modal_error].to_i == hospital.id %>
           <div class="alert alert-danger">
             <ul>
@@ -381,11 +381,10 @@
 <% end %>
 
 <!-- 病院情報 新規追加モーダル -->
-<!-- 病院情報 新規追加モーダル -->
 <div class="modal fade" id="newHospitalModal" tabindex="-1" aria-labelledby="newHospitalModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-      <%= form_with model: Hospital.new, url: hospitals_path, local: true do |f| %>
+      <%= form_with(model: [@current_child, Hospital.new], url: child_hospitals_path(@current_child), local: true) do |f| %>
         <div class="modal-header">
           <h5 class="modal-title" id="newHospitalModalLabel">病院を追加</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
@@ -402,14 +401,17 @@
             </div>
           <% end %>
 
+          <!-- 🔒 child_id を hidden_field で明示 -->
+          <%= f.hidden_field :child_id, value: @current_child&.id %>
+
           <div class="mb-3">
             <%= f.label :name, "病院名" %>
-            <%= f.text_field :name, value: flash[:hospital_attributes]&.[]("name"), class: "form-control" %>
+            <%= f.text_field :name, value: flash[:hospital_attributes]&.[]("name"), class: "form-control", id: "hospital_name" %>
           </div>
 
           <div class="mb-3">
             <%= f.label :phone_number, "電話番号" %>
-            <%= f.telephone_field :phone_number, value: flash[:hospital_attributes]&.[]("phone_number"), class: "form-control" %>
+            <%= f.telephone_field :phone_number, value: flash[:hospital_attributes]&.[]("phone_number"), class: "form-control", id: "hospital_phone_number" %>
           </div>
         </div>
 

--- a/app/views/shared/_care_relationship.html.erb
+++ b/app/views/shared/_care_relationship.html.erb
@@ -1,26 +1,38 @@
 <%= turbo_frame_tag "care_relationship_#{care_relationship.id}" do %>
-  <div class="border rounded p-2 mb-3" data-controller="highlight">
-    <p><strong>子ども：</strong><%= care_relationship.child.name %></p>
-    <p><strong>保育者：</strong><%= care_relationship.caregiver.nickname %></p>
-    <p>
-      <strong>現在：</strong>
-      <% if care_relationship.ongoing? %>
-        <span class="badge bg-success">預かり中</span>
-      <% else %>
-        <span class="badge bg-secondary">終了</span>
-      <% end %>
-    </p>
+  <div class="border rounded p-3 mb-3">
+    <div class="mb-2">
+      <strong>子ども：</strong><%= care_relationship.child.name %><br>
+      <strong>保育者：</strong><%= care_relationship.caregiver.nickname %>
+    </div>
 
-    <!-- ステータス切替ボタン -->
-    <%= button_to "ステータス切替", care_relationship_path(care_relationship),
-          method: :patch,
-          data: { turbo_frame: "care_relationship_#{care_relationship.id}" },
-          class: "btn btn-sm btn-outline-primary" %>
+    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+      <div>
+        <strong>現在：</strong>
+        <% if care_relationship.ongoing? %>
+          <span class="badge bg-success">預け中</span>
+        <% else %>
+          <span class="badge bg-secondary">預け終了</span>
+        <% end %>
+      </div>
 
-    <!-- 🔥 追加：削除ボタン（Turbo対応） -->
-    <%= button_to "削除", care_relationship_path(care_relationship),
-          method: :delete,
-          data: { turbo_stream: true },
-          class: "btn btn-sm btn-outline-danger ms-2" %>
+      <div class="d-flex gap-2">
+        <% if care_relationship.ongoing? %>
+          <%= button_to "預け終了", care_relationship_path(care_relationship),
+                method: :patch,
+                data: { turbo_frame: "care_relationship_#{care_relationship.id}" },
+                class: "btn btn-sm btn-outline-secondary" %>
+        <% else %>
+          <%= button_to "預ける", care_relationship_path(care_relationship),
+                method: :patch,
+                data: { turbo_frame: "care_relationship_#{care_relationship.id}" },
+                class: "btn btn-sm btn-outline-success" %>
+        <% end %>
+
+        <%= button_to "削除", care_relationship_path(care_relationship),
+              method: :delete,
+              data: { turbo_stream: true, confirm: "本当に削除しますか？" },
+              class: "btn btn-sm btn-outline-danger" %>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/shared/_hospital_form_modal.html.erb
+++ b/app/views/shared/_hospital_form_modal.html.erb
@@ -1,20 +1,34 @@
 <div class="modal fade" id="newHospitalModal" tabindex="-1" aria-labelledby="newHospitalModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-      <%= form_with model: @hospital || current_user.hospitals.build, url: hospitals_path, data: { turbo_frame: "_top" }, method: :post do |f| %>
+      <%= form_with model: (@hospital || Hospital.new), url: child_hospitals_path(@current_child), method: :post, local: true do |f| %>
         <div class="modal-header">
           <h5 class="modal-title" id="newHospitalModalLabel">病院を追加</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
         </div>
 
+        <div class="modal-body">
+          <% if flash[:hospital_errors] %>
+            <div class="alert alert-danger">
+              <ul class="mb-0">
+                <% flash[:hospital_errors].each do |msg| %>
+                  <li><%= msg %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <!-- ✅ child_idをhiddenで送信（保護） -->
+          <%= f.hidden_field :child_id, value: @current_child&.id %>
+
           <div class="mb-3">
             <%= f.label :name, "病院名" %>
-            <%= f.text_field :name, class: "form-control" %>
+            <%= f.text_field :name, value: flash[:hospital_attributes]&.[]("name"), class: "form-control" %>
           </div>
 
           <div class="mb-3">
             <%= f.label :phone_number, "電話番号" %>
-            <%= f.telephone_field :phone_number, class: "form-control" %>
+            <%= f.telephone_field :phone_number, value: flash[:hospital_attributes]&.[]("phone_number"), class: "form-control" %>
           </div>
         </div>
 

--- a/app/views/shared/_hospital_form_modal.html.erb
+++ b/app/views/shared/_hospital_form_modal.html.erb
@@ -1,11 +1,12 @@
 <div class="modal fade" id="newHospitalModal" tabindex="-1" aria-labelledby="newHospitalModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-      <%= form_with model: (@hospital || Hospital.new), url: child_hospitals_path(@current_child), method: :post, local: true do |f| %>
-        <div class="modal-header">
-          <h5 class="modal-title" id="newHospitalModalLabel">病院を追加</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
-        </div>
+      <% if @current_child.present? %>
+        <%= form_with(model: [@current_child, @hospital], url: child_hospitals_path(@current_child), local: true) do |f| %>
+          <div class="modal-header">
+            <h5 class="modal-title" id="newHospitalModalLabel">病院を追加</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+          </div>
 
         <div class="modal-body">
           <% if flash[:hospital_errors] %>
@@ -34,6 +35,10 @@
 
         <div class="modal-footer">
           <%= f.submit "追加する", class: "btn btn-primary" %>
+          <% end %>
+      <% else %>
+        <div class="alert alert-warning m-3">
+          先に子どもを登録してください。
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_hospital_form_modal.html.erb
+++ b/app/views/shared/_hospital_form_modal.html.erb
@@ -1,46 +1,41 @@
 <div class="modal fade" id="newHospitalModal" tabindex="-1" aria-labelledby="newHospitalModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
-      <% if @current_child.present? %>
-        <%= form_with(model: [@current_child, @hospital], url: child_hospitals_path(@current_child), local: true) do |f| %>
-          <div class="modal-header">
-            <h5 class="modal-title" id="newHospitalModalLabel">病院を追加</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
-          </div>
+      <div class="modal-header">
+        <h5 class="modal-title" id="newHospitalModalLabel">病院を追加</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+      </div>
 
-        <div class="modal-body">
-          <% if flash[:hospital_errors] %>
-            <div class="alert alert-danger">
-              <ul class="mb-0">
-                <% flash[:hospital_errors].each do |msg| %>
-                  <li><%= msg %></li>
-                <% end %>
-              </ul>
+      <div class="modal-body">
+        <% if flash[:hospital_errors] %>
+          <div class="alert alert-danger">
+            <ul>
+              <% flash[:hospital_errors].each do |msg| %>
+                <li><%= msg %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <% if @current_child.present? %>
+          <%= form_with(model: [@current_child, @hospital], url: child_hospitals_path(@current_child), local: true) do |f| %>
+            <%= f.hidden_field :child_id, value: @current_child.id %>
+            <div class="mb-3">
+              <%= f.label :name, "病院名" %>
+              <%= f.text_field :name, class: "form-control" %>
+            </div>
+            <div class="mb-3">
+              <%= f.label :phone_number, "電話番号" %>
+              <%= f.telephone_field :phone_number, class: "form-control" %>
+            </div>
+            <div class="modal-footer">
+              <%= f.submit "追加する", class: "btn btn-primary" %>
             </div>
           <% end %>
-
-          <!-- ✅ child_idをhiddenで送信（保護） -->
-          <%= f.hidden_field :child_id, value: @current_child&.id %>
-
-          <div class="mb-3">
-            <%= f.label :name, "病院名" %>
-            <%= f.text_field :name, value: flash[:hospital_attributes]&.[]("name"), class: "form-control" %>
-          </div>
-
-          <div class="mb-3">
-            <%= f.label :phone_number, "電話番号" %>
-            <%= f.telephone_field :phone_number, value: flash[:hospital_attributes]&.[]("phone_number"), class: "form-control" %>
-          </div>
-        </div>
-
-        <div class="modal-footer">
-          <%= f.submit "追加する", class: "btn btn-primary" %>
-          <% end %>
-      <% else %>
-        <div class="alert alert-warning m-3">
-          先に子どもを登録してください。
-        </div>
-      <% end %>
+        <% else %>
+          <p class="text-muted">子どもを選択してください。</p>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/shared/_record_modal.html.erb
+++ b/app/views/shared/_record_modal.html.erb
@@ -6,48 +6,53 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
-        <% if @children.present? %>
-<%= form_with(model: [@current_child, @record || Record.new], url: child_records_path(@current_child), local: true) do |f| %>
-  <% if flash[:record_errors] %>
-    <div class="alert alert-danger">
-      <ul class="mb-0">
-        <% flash[:record_errors].each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+        <% if @children.present? && @current_child.present? && (!@is_shared_child || @is_shared_child) %>
+          <%= form_with(model: [@current_child, @record || Record.new], url: child_records_path(@current_child), local: true) do |f| %>
+            <% if flash[:record_errors] %>
+              <div class="alert alert-danger">
+                <ul class="mb-0">
+                  <% flash[:record_errors].each do |msg| %>
+                    <li><%= msg %></li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
 
-
-      <div class="mb-3">
-        <%= f.label :record_type, "記録の種類" %>
-    <%= f.select :record_type,
-      Record.record_types.keys.map { |key| [I18n.t("activerecord.attributes.record.record_type.#{key}"), key] },
-      {}, class: "form-select" %>
-      </div>
-      <div class="mb-3">
-        <%= f.label :category, "カテゴリ" %>
-    <%= f.select :category,
-      Record.categories.keys.map { |key| [I18n.t("activerecord.attributes.record.category.#{key}"), key] },
-      {}, class: "form-select" %>
-      </div>
             <div class="mb-3">
-              <%= f.label :quantity, "量や回数" %>
-              <%= f.number_field :quantity, class: "form-control" %>
+              <%= f.label :record_type, "記録の種類" %>
+              <%= f.select :record_type,
+                  Record.record_types.keys.map { |key| [I18n.t("activerecord.attributes.record.record_type.#{key}"), key] },
+                  {}, class: "form-select" %>
             </div>
+
+            <div class="mb-3">
+              <%= f.label :category, "カテゴリ" %>
+              <%= f.select :category,
+                  Record.categories.keys.map { |key| [I18n.t("activerecord.attributes.record.category.#{key}"), key] },
+                  {}, class: "form-select" %>
+            </div>
+
+            <div class="mb-3">
+  <%= f.label :quantity, "量や回数" %>
+<%= f.number_field :quantity, class: "form-control", value: f.object.quantity || 1 %>
+            </div>
+
             <div class="mb-3">
               <%= f.label :recorded_at, "記録日時" %>
-    <%= f.datetime_local_field :recorded_at, value: Time.current.strftime("%Y-%m-%dT%H:%M"), class: "form-control" %>            </div>
+              <%= f.datetime_local_field :recorded_at, value: Time.current.strftime("%Y-%m-%dT%H:%M"), class: "form-control" %>
+            </div>
+
             <div class="mb-3">
               <%= f.label :memo, "メモ" %>
               <%= f.text_area :memo, class: "form-control", rows: 2 %>
             </div>
+
             <div class="text-end">
               <%= f.submit "記録する", class: "btn btn-primary" %>
             </div>
           <% end %>
         <% else %>
-          <p>まず子どもを登録してください。</p>
+          <p class="text-muted">まず子どもを登録してください。</p>
         <% end %>
       </div>
     </div>

--- a/app/views/shared/_record_modal.html.erb
+++ b/app/views/shared/_record_modal.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="modal-body">
         <% if @children.present? %>
-<%= form_with(model: [@children.first, @record || Record.new], url: child_records_path(@children.first), local: true) do |f| %>
+<%= form_with(model: [@current_child, @record || Record.new], url: child_records_path(@current_child), local: true) do |f| %>
   <% if flash[:record_errors] %>
     <div class="alert alert-danger">
       <ul class="mb-0">

--- a/app/views/shared/_routine_modal.html.erb
+++ b/app/views/shared/_routine_modal.html.erb
@@ -17,7 +17,7 @@
   </div>
 <% end %>
 
-        <% if @children.present? %>
+        <% if @current_child.present? %>
 <%= form_with(model: [@current_child, Routine.new(flash[:routine_attributes] || {})], url: child_routines_path(@current_child), local: true) do |f| %>
             <div class="mb-3">
               <%= f.label :time, "時間" %>

--- a/app/views/shared/_routine_modal.html.erb
+++ b/app/views/shared/_routine_modal.html.erb
@@ -18,8 +18,7 @@
 <% end %>
 
         <% if @children.present? %>
-<%= form_with(model: [@children.first, Routine.new(flash[:routine_attributes] || {})], url: child_routines_path(@children.first), local: true, html: { multipart: true }) do |f| %>
-
+<%= form_with(model: [@current_child, Routine.new(flash[:routine_attributes] || {})], url: child_routines_path(@current_child), local: true) do |f| %>
             <div class="mb-3">
               <%= f.label :time, "時間" %>
               <%= f.time_field :time, class: "form-control" %>
@@ -56,21 +55,21 @@
         <h5 class="modal-title" id="routineDetailModalLabel">ルーティン一覧</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
-      <div class="modal-body">
-        <% if @children.first && @children.first.routines.any? %>
-          <ul class="list-group">
-            <% @children.first.routines.order(:time).each do |routine| %>
-              <% task_value = routine.task_before_type_cast.to_i %>
-              <% task_key = Routine.tasks.key(task_value) %>
-              <% task_label = Routine.task_labels[task_key] || "不明なタスク" %>
-              <li class="list-group-item d-flex justify-content-between align-items-start">
-                <div>
-                  <strong><%= task_label %></strong>
-                  <div class="text-muted small">🕒 <%= routine.time.strftime('%H:%M') %></div>
-                  <% if routine.memo.present? %>
-                    <div class="text-muted small">📝 <%= routine.memo %></div>
-                  <% end %>
-                </div>
+<div class="modal-body">
+  <% if @current_child && @current_child.routines.any? %>
+    <ul class="list-group">
+      <% @current_child.routines.order(:time).each do |routine| %>
+        <% task_value = routine.task_before_type_cast.to_i %>
+        <% task_key = Routine.tasks.key(task_value) %>
+        <% task_label = Routine.task_labels[task_key] || "不明なタスク" %>
+        <li class="list-group-item d-flex justify-content-between align-items-start">
+          <div>
+            <strong><%= task_label %></strong>
+            <div class="text-muted small">🕒 <%= routine.time.strftime('%H:%M') %></div>
+            <% if routine.memo.present? %>
+              <div class="text-muted small">📝 <%= routine.memo %></div>
+            <% end %>
+          </div>
 
                 <!-- 編集・削除ボタン -->
                 <div class="text-end">

--- a/app/views/shared/_routine_modal.html.erb
+++ b/app/views/shared/_routine_modal.html.erb
@@ -71,16 +71,19 @@
             <% end %>
           </div>
 
-                <!-- 編集・削除ボタン -->
-                <div class="text-end">
-<%= link_to "編集", "#", class: "btn btn-sm btn-outline-secondary", data: { bs_toggle: "modal", bs_target: "#editRoutineModal-#{routine.id}", turbo: false } %>
-                  <%= button_to "削除", child_routine_path(routine.child_id, routine),
-                      method: :delete,
-                      data: { turbo_confirm: "本当に削除しますか？" },
-                      class: "btn btn-sm btn-outline-danger",
-                      form: { class: "d-inline" } %>
-                </div>
-              </li>
+  <!-- 編集・削除ボタン -->
+<% if current_user.id == routine.child.user_id %>
+  <div class="text-end">
+    <%= link_to "編集", "#", class: "btn btn-sm btn-outline-secondary",
+                data: { bs_toggle: "modal", bs_target: "#editRoutineModal-#{routine.id}", turbo: false } %>
+
+    <%= button_to "削除", child_routine_path(routine.child_id, routine),
+        method: :delete,
+        data: { turbo_confirm: "本当に削除しますか？" },
+        class: "btn btn-sm btn-outline-danger",
+        form: { class: "d-inline" } %>
+  </div>
+<% end %>
 
               <!-- 編集モーダル（個別に出力） -->
               <div class="modal fade" id="editRoutineModal-<%= routine.id %>" tabindex="-1" aria-labelledby="editRoutineModalLabel-<%= routine.id %>" aria-hidden="true">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   root to: 'homes#index'
 
   devise_for :users
+
   get 'up' => 'rails/health#show', as: :rails_health_check
+
+  # 子ども選択用ルート（ドロップダウンからの切替に使用）
+  patch 'select_child/:id', to: 'children#select', as: :select_child
 
   resources :homes, only: [:index]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,8 @@ Rails.application.routes.draw do
   resources :children, only: [:new, :create, :index, :show, :update] do
     resources :records, only: [:create, :update, :destroy]
     resources :routines
+    resources :hospitals, only: [:new, :create, :update]
   end
-
-  resources :hospitals, only: [:new, :create, :update]
 
   resources :care_relationships, only: [:create, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   resources :homes, only: [:index]
 
-  resources :children, only: [:new, :create, :index, :show, :update] do
+  resources :children, only: [:new, :create, :index, :show, :update, :destroy] do
     resources :records, only: [:create, :update, :destroy]
     resources :routines
     resources :hospitals, only: [:new, :create, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   get 'up' => 'rails/health#show', as: :rails_health_check
 
-  # 子ども選択用ルート（ドロップダウンからの切替に使用）
+  # ✅ 子ども選択用ルート（ドロップダウンからの切替に使用）
   patch 'select_child/:id', to: 'children#select', as: :select_child
 
   resources :homes, only: [:index]

--- a/db/migrate/20250506134639_add_user_id_to_records.rb
+++ b/db/migrate/20250506134639_add_user_id_to_records.rb
@@ -1,0 +1,5 @@
+class AddUserIdToRecords < ActiveRecord::Migration[7.1]
+  def change
+    add_column :records, :user_id, :bigint
+  end
+end

--- a/db/migrate/20250506135433_add_child_id_to_hospitals.rb
+++ b/db/migrate/20250506135433_add_child_id_to_hospitals.rb
@@ -1,0 +1,5 @@
+class AddChildIdToHospitals < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :hospitals, :child, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_05_090359) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_06_134639) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -79,6 +79,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_05_090359) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "category"
+    t.bigint "user_id"
     t.index ["child_id"], name: "index_records_on_child_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_06_134639) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_06_135433) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -67,6 +67,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_06_134639) do
     t.string "phone_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "child_id", null: false
+    t.index ["child_id"], name: "index_hospitals_on_child_id"
     t.index ["user_id"], name: "index_hospitals_on_user_id"
   end
 
@@ -121,6 +123,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_06_134639) do
   add_foreign_key "care_relationships", "users", column: "caregiver_id"
   add_foreign_key "care_relationships", "users", column: "parent_id"
   add_foreign_key "children", "users"
+  add_foreign_key "hospitals", "children"
   add_foreign_key "hospitals", "users"
   add_foreign_key "records", "children"
   add_foreign_key "routines", "children"


### PR DESCRIPTION
#What
保育関係（CareRelationship）の状態に応じたUI表示を統一（預ける／預かり終了ボタンなど）
Turbo Frame対応で保育者ステータスの非同期切り替えを実装
モーダルとパーシャルで重複していた関係者情報表示を統合
子ども一覧へのアクセス制御を厳密化（保育者が不要な子どもを選べないように修正）

#Why
預かり機能における保護者・保育者双方の画面表示の一貫性を保つため
UIの重複によるメンテナンス負荷を削減するため
モーダルとパーシャルで重複していた関係者情報表示を統合
子ども一覧へのアクセス制御を厳密化（保育者が不要な子どもを選べないように修正）