### PR TITLE
バグ改善

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -29,6 +29,10 @@ class ChildrenController < ApplicationController
     ]
   end
 
+  def new
+    @child = Child.new
+  end
+
   def select
     child = Child.find_by(id: params[:id])
 

--- a/app/controllers/hospitals_controller.rb
+++ b/app/controllers/hospitals_controller.rb
@@ -9,8 +9,7 @@ class HospitalsController < ApplicationController
     if @hospital.save
       redirect_to root_path, notice: "病院を登録しました"
     else
-      # flashを使ってエラー内容と入力値を一時的に保持
-      flash[:hospital_modal_error] = "new" # newの合図
+      flash[:hospital_modal_error] = "new"
       flash[:hospital_errors] = @hospital.errors.full_messages
       flash[:hospital_attributes] = hospital_params
       redirect_to root_path
@@ -25,7 +24,7 @@ class HospitalsController < ApplicationController
     else
       flash[:hospital_modal_error] = @hospital.id
       flash[:hospital_errors] = @hospital.errors.full_messages
-      redirect_to root_path # @hospitalは渡らないので、必要ならsessionなど使う
+      redirect_to root_path
     end
   end
 

--- a/app/javascript/home.js
+++ b/app/javascript/home.js
@@ -276,3 +276,12 @@ document.addEventListener("turbo:load", () => {
     });
   });
 });
+
+document.addEventListener("turbo:load", () => {
+  // 緊急連絡先モーダルが閉じられたら、エラーメッセージを削除する
+  document.querySelectorAll("[id^='editHospitalModal-'], #newHospitalModal").forEach(modalEl => {
+    modalEl.addEventListener("hidden.bs.modal", () => {
+      modalEl.querySelectorAll(".alert").forEach(alert => alert.remove());
+    });
+  });
+});

--- a/app/javascript/home.js
+++ b/app/javascript/home.js
@@ -18,8 +18,9 @@ window.showRoutine = function(childId, childName) {
   const nowMinutes = now.getHours() * 60 + now.getMinutes();
 
   function timeToMinutes(timeStr) {
+    if (!timeStr) return Infinity;
     const [hour, minute] = timeStr.split(":").map(Number);
-    return hour * 60 + minute;
+    return (hour || 0) * 60 + (minute || 0);
   }
 
   let nextTask = "なし";

--- a/app/javascript/home.js
+++ b/app/javascript/home.js
@@ -59,16 +59,35 @@ document.addEventListener("turbo:load", () => {
     }
   }
 
-  // ✅ 病院編集モーダル
-  const editHospitalId = document.body.dataset.hospitalModalError;
-  if (editHospitalId) {
-    const modalEl = document.getElementById(`editHospitalModal-${editHospitalId}`);
-    if (modalEl) {
-      const modal = new bootstrap.Modal(modalEl);
-      modal.show();
-      document.body.dataset.hospitalModalError = "";
+// ✅ 病院モーダル再表示（新規 or 編集）
+const hospitalModalError = document.body.dataset.hospitalModalError;
+
+if (hospitalModalError) {
+  const modalId = hospitalModalError === "new"
+    ? "newHospitalModal"
+    : `editHospitalModal-${hospitalModalError}`;
+  const modalEl = document.getElementById(modalId);
+
+  if (modalEl) {
+    // 既にモーダルが開いていたら閉じてから再表示
+    const opened = document.querySelector(".modal.show");
+    if (opened && opened.id !== modalId) {
+      const openedInstance = bootstrap.Modal.getInstance(opened);
+      if (openedInstance) {
+        opened.addEventListener("hidden.bs.modal", () => {
+          new bootstrap.Modal(modalEl).show();
+        }, { once: true });
+        openedInstance.hide();
+      } else {
+        new bootstrap.Modal(modalEl).show();
+      }
+    } else {
+      new bootstrap.Modal(modalEl).show();
     }
+
+    document.body.dataset.hospitalModalError = "";
   }
+}
 
   // ✅ 子どもモーダル（new/edit）
   const childModalError = document.body.dataset.childModalError;

--- a/app/models/care_relationship.rb
+++ b/app/models/care_relationship.rb
@@ -4,11 +4,25 @@ class CareRelationship < ApplicationRecord
   belongs_to :child
 
   enum status: { ongoing: 0, ended: 1 }
+
+  # 日本語化ヘルパー
   def status_i18n
     I18n.t("enums.care_relationship.status.#{status}")
   end
+
+  # バリデーション
   validates :parent, presence: { message: "を入力してください" }
   validates :caregiver, presence: { message: "を入力してください" }
   validates :child, presence: { message: "を入力してください" }
   validates :status, presence: { message: "を入力してください" }
+
+  validate :parent_cannot_be_caregiver
+
+  private
+
+  def parent_cannot_be_caregiver
+    return unless parent_id == caregiver_id
+
+    errors.add(:caregiver_id, "に自分自身は指定できません")
+  end
 end

--- a/app/models/routine.rb
+++ b/app/models/routine.rb
@@ -38,6 +38,6 @@ class Routine < ApplicationRecord
 
   # インスタンス用
   def task_label
-    I18n.t("activerecord.attributes.record.record_type.#{task}")
+    I18n.t("enums.record.record_type.#{task}")
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -135,7 +135,7 @@
         <% end %>
 
         <div class="record-user text-muted small mt-1">
-          👤 記録者：<%= record.user.nickname %>
+          👤 ：<%= record.user.nickname %>
         </div>
       </div>
 

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -109,8 +109,10 @@
     </div>
   <% end %>
 
-  <!-- 記録一覧 -->
-<h5 class="record-title fw-bold mb-3">記録一覧（<%= @selected_date&.strftime('%Y年%m月%d日') || "日付不明" %>）</h5>
+<!-- 記録一覧 -->
+<h5 class="record-title fw-bold mb-3">
+  記録一覧（<%= @selected_date&.strftime('%Y年%m月%d日') || "日付不明" %>）
+</h5>
 
 <ul class="list-group record-list">
   <% @records.order(recorded_at: :desc).each do |record| %>
@@ -119,15 +121,22 @@
         <div class="record-time-type mb-1">
           <strong class="record-time"><%= record.recorded_at.strftime('%H:%M') %></strong>
           <%= icon_for(record.record_type) %>
-          <%= I18n.t("activerecord.attributes.record.record_type.#{record.record_type}") %>
+          <%= I18n.t("enums.record.record_type.#{record.record_type}") %>
           <span class="record-quantity badge bg-light text-dark ms-2"><%= record.quantity %></span>
+        </div>
+
+        <!-- ✅ カテゴリ表示 -->
+        <div class="record-category text-muted small">
+          🗂️ ：<%= I18n.t("enums.record.category.#{record.category}") %>
         </div>
 
         <% if record.memo.present? %>
           <div class="record-memo text-muted small">💬 <%= record.memo %></div>
         <% end %>
 
-        <div class="record-user text-muted small mt-1">👤 記録者：<%= record.user.nickname %></div>
+        <div class="record-user text-muted small mt-1">
+          👤 記録者：<%= record.user.nickname %>
+        </div>
       </div>
 
       <div class="record-actions text-nowrap">
@@ -141,43 +150,52 @@
                       class: "btn btn-sm btn-outline-danger" %>
       </div>
     </li>
-      <!-- 編集モーダル -->
-      <div class="modal fade" id="editRecordModal-<%= record.id %>" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <%= form_with(model: [record.child, record], local: true) do |f| %>
-              <div class="modal-header">
-                <h5 class="modal-title">記録を編集</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-              </div>
-              <div class="modal-body">
-                <% if flash[:open_modal] == "editRecordModal-#{record.id}" && flash[:record_errors] %>
-                  <div class="alert alert-danger">
-                    <ul class="mb-0">
-                      <% flash[:record_errors].each do |msg| %>
-                        <li><%= msg %></li>
-                      <% end %>
-                    </ul>
-                  </div>
-                <% end %>
-                <%= f.label :record_type, "記録の種類" %>
-                <%= f.select :record_type, Record.record_types.keys.map { |key| [I18n.t("activerecord.attributes.record.record_type.#{key}"), key] }, {}, class: "form-select mb-2" %>
-                <%= f.label :category, "カテゴリ" %>
-                <%= f.select :category, Record.categories.keys.map { |key| [I18n.t("activerecord.attributes.record.category.#{key}"), key] }, {}, class: "form-select mb-2" %>
-                <%= f.label :quantity, "量や回数" %>
-                <%= f.number_field :quantity, class: "form-control mb-2" %>
-                <%= f.label :recorded_at, "日時" %>
-                <%= f.datetime_local_field :recorded_at, class: "form-control mb-2" %>
-                <%= f.label :memo, "メモ" %>
-                <%= f.text_area :memo, class: "form-control", rows: 2 %>
-              </div>
-              <div class="modal-footer">
-                <%= f.submit "更新", class: "btn btn-primary" %>
-              </div>
-            <% end %>
-          </div>
+<!-- 編集モーダル -->
+<div class="modal fade" id="editRecordModal-<%= record.id %>" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <%= form_with(model: [record.child, record], local: true) do |f| %>
+        <div class="modal-header">
+          <h5 class="modal-title">記録を編集</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
         </div>
-      </div>
+        <div class="modal-body">
+          <% if flash[:open_modal] == "editRecordModal-#{record.id}" && flash[:record_errors] %>
+            <div class="alert alert-danger">
+              <ul class="mb-0">
+                <% flash[:record_errors].each do |msg| %>
+                  <li><%= msg %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <%= f.label :record_type, "記録の種類" %>
+          <%= f.select :record_type,
+              Record.record_types.keys.map { |key| [I18n.t("enums.record.record_type.#{key}"), key] },
+              {}, class: "form-select mb-2" %>
+
+          <%= f.label :category, "カテゴリ" %>
+          <%= f.select :category,
+              Record.categories.keys.map { |key| [I18n.t("enums.record.category.#{key}"), key] },
+              {}, class: "form-select mb-2" %>
+
+          <%= f.label :quantity, "量や回数" %>
+          <%= f.number_field :quantity, class: "form-control mb-2" %>
+
+          <%= f.label :recorded_at, "日時" %>
+          <%= f.datetime_local_field :recorded_at, class: "form-control mb-2" %>
+
+          <%= f.label :memo, "メモ" %>
+          <%= f.text_area :memo, class: "form-control", rows: 2 %>
+        </div>
+        <div class="modal-footer">
+          <%= f.submit "更新", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
     <% end %>
   </ul>
 </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -361,15 +361,15 @@
     <div class="modal-dialog">
       <div class="modal-content">
 <%= form_with(model: [hospital.child, hospital], url: child_hospital_path(hospital.child, hospital), method: :patch, local: true) do |f| %>
-        <% if flash[:hospital_errors] && flash[:hospital_modal_error].to_i == hospital.id %>
-          <div class="alert alert-danger">
-            <ul>
-              <% flash[:hospital_errors].each do |msg| %>
-                <li><%= msg %></li>
-              <% end %>
-            </ul>
-          </div>
-        <% end %>
+<% if flash[:hospital_errors] && flash[:hospital_modal_error].to_i == hospital.id %>
+  <div class="alert alert-danger">
+    <ul>
+      <% flash[:hospital_errors].each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 
           <div class="modal-header">
             <h5 class="modal-title" id="editHospitalModalLabel-<%= hospital.id %>">緊急連絡情報を編集</h5>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,17 +17,22 @@
 
 <body
   data-open-modal="<%= flash[:open_modal] %>"
+
   data-hospital-modal-error="<%= flash[:hospital_modal_error] %>"
   data-hospital-errors="<%= (flash[:hospital_errors] || []).to_json %>"           
-  data-hospital-attributes="<%= (flash[:hospital_attributes] || {}).to_json %>"    
+  data-hospital-attributes="<%= (flash[:hospital_attributes] || {}).to_json %>"
+
   data-child-modal-error="<%= flash[:child_modal_error] %>"
+
   data-routine-modal-error="<%= flash[:routine_modal_error] %>"
   data-routine-errors="<%= (flash[:routine_errors] || []).to_json %>"
   data-routine-attributes="<%= (flash[:routine_attributes] || {}).to_json %>"
+
+  data-record-modal-error="<%= flash[:record_modal_error] == 'new' ? 'true' : '' %>"
   data-record-errors="<%= (flash[:record_errors] || []).to_json %>"
   data-record-attributes="<%= (flash[:record_attributes] || {}).to_json %>"
-  data-record-modal-error="<%= flash[:record_modal_error] %>">
-    <main>
+>
+  <main>
       <%= yield %>
     </main>
   </body>

--- a/app/views/shared/_hospital_form_modal.html.erb
+++ b/app/views/shared/_hospital_form_modal.html.erb
@@ -7,15 +7,15 @@
       </div>
 
       <div class="modal-body">
-        <% if flash[:hospital_errors] %>
-          <div class="alert alert-danger">
-            <ul>
-              <% flash[:hospital_errors].each do |msg| %>
-                <li><%= msg %></li>
-              <% end %>
-            </ul>
-          </div>
-        <% end %>
+<% if flash[:hospital_errors] && flash[:hospital_modal_error] == "new" %>
+  <div class="alert alert-danger">
+    <ul>
+      <% flash[:hospital_errors].each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 
         <% if @current_child.present? %>
           <%= form_with(model: [@current_child, @hospital], url: child_hospitals_path(@current_child), local: true) do |f| %>

--- a/app/views/shared/_record_modal.html.erb
+++ b/app/views/shared/_record_modal.html.erb
@@ -21,20 +21,20 @@
             <div class="mb-3">
               <%= f.label :record_type, "記録の種類" %>
               <%= f.select :record_type,
-                  Record.record_types.keys.map { |key| [I18n.t("activerecord.attributes.record.record_type.#{key}"), key] },
+                  Record.record_types.keys.map { |key| [I18n.t("enums.record.record_type.#{key}"), key] },
                   {}, class: "form-select" %>
             </div>
 
             <div class="mb-3">
               <%= f.label :category, "カテゴリ" %>
               <%= f.select :category,
-                  Record.categories.keys.map { |key| [I18n.t("activerecord.attributes.record.category.#{key}"), key] },
+                  Record.categories.keys.map { |key| [I18n.t("enums.record.category.#{key}"), key] },
                   {}, class: "form-select" %>
             </div>
 
             <div class="mb-3">
-  <%= f.label :quantity, "量や回数" %>
-<%= f.number_field :quantity, class: "form-control", value: f.object.quantity || 1 %>
+              <%= f.label :quantity, "量や回数" %>
+              <%= f.number_field :quantity, class: "form-control", value: f.object.quantity || 1 %>
             </div>
 
             <div class="mb-3">

--- a/app/views/shared/_routine_modal.html.erb
+++ b/app/views/shared/_routine_modal.html.erb
@@ -74,7 +74,6 @@
   <!-- 編集・削除ボタン -->
 <% if current_user.id == routine.child.user_id %>
   <div class="text-end">
-<button type="button" class="btn btn-sm btn-outline-secondary" data-open-next-modal="editRoutineModal-<%= routine.id %>">編集</button>
  <%= button_to "削除", child_routine_path(routine.child_id, routine),
         method: :delete,
         data: { turbo_confirm: "本当に削除しますか？" },

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,28 +6,6 @@ ja:
 
     attributes:
       record:
-        record_type:
-          milk: "ミルク"
-          breast_milk: "母乳"
-          baby_food: "離乳食"
-          water: "水分補給"
-          sleep: "睡眠"
-          nap: "昼寝"
-          toilet: "排泄"
-          temperature: "体温"
-          medicine: "服薬"
-          hospital: "通院・予防接種"
-          bath: "お風呂"
-          outing: "外出"
-          event: "行事"
-          concern: "気になる様子"
-        category:
-          nutrition: "栄養"
-          life: "生活"
-          health: "健康"
-          medical: "医療"
-          schedule: "スケジュール"
-          concern_note: "気になること"
         quantity: "回数"
         recorded_at: "記録日時"
 
@@ -47,10 +25,35 @@ ja:
         birth_date: "生年月日"
 
       routine:
-        task: "記録の種類"        # 英語「Task」を日本語表示に
+        task: "記録の種類"
         time: "時間"
-        
+
   enums:
+    record:
+      record_type:
+        milk: "ミルク"
+        breast_milk: "母乳"
+        baby_food: "離乳食"
+        water: "水分補給"
+        sleep: "睡眠"
+        nap: "昼寝"
+        toilet: "排泄"
+        temperature: "体温"
+        medicine: "服薬"
+        hospital: "通院・予防接種"
+        bath: "お風呂"
+        outing: "外出"
+        event: "行事"
+        concern: "気になる様子"
+
+      category:
+        nutrition: "栄養"
+        life: "生活"
+        health: "健康"
+        medical: "医療"
+        schedule: "スケジュール"
+        concern_note: "気になること"
+
     care_relationship:
       status:
         ongoing: "預かり中"
@@ -60,7 +63,7 @@ ja:
     messages:
       blank: "を入力してください"
       not_a_number: "は数値で入力してください"
-      greater_than: "は1以上を入力してください"  # ✅ %{attribute} を削除
+      greater_than: "は1以上を入力してください"
 
     models:
       record:
@@ -71,7 +74,6 @@ ja:
             blank: "カテゴリを選択してください"
           quantity:
             blank: "を入力してください"
-            greater_than: "は1以上を入力してください"  # ✅ 個別でも同様に調整
+            greater_than: "は1以上を入力してください"
           recorded_at:
             blank: "記録日時を入力してください"
-    care_relationship:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,7 +40,16 @@ ja:
         caregiver: "保育者"
         child: "子ども"
         status: "ステータス"
+        caregiver_id: "預け先"
 
+      child:
+        name: "名前"
+        birth_date: "生年月日"
+
+      routine:
+        task: "記録の種類"        # 英語「Task」を日本語表示に
+        time: "時間"
+        
   enums:
     care_relationship:
       status:
@@ -65,3 +74,4 @@ ja:
             greater_than: "は1以上を入力してください"  # ✅ 個別でも同様に調整
           recorded_at:
             blank: "記録日時を入力してください"
+    care_relationship:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   resources :homes, only: [:index]
 
-  resources :children, only: [:new, :create, :index, :show, :update, :destroy] do
+  resources :children do
     resources :records, only: [:create, :update, :destroy]
     resources :routines
     resources :hospitals, only: [:new, :create, :update]

--- a/db/migrate/20250504135909_change_routine_time_to_time.rb
+++ b/db/migrate/20250504135909_change_routine_time_to_time.rb
@@ -1,6 +1,13 @@
-# db/migrate/xxxxxx_change_routine_time_to_time.rb
 class ChangeRoutineTimeToTime < ActiveRecord::Migration[7.1]
-  def change
-    change_column :routines, :time, :time
+  def up
+    if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+      change_column :routines, :time, 'time USING time::time'
+    else
+      change_column :routines, :time, :time
+    end
+  end
+
+  def down
+    change_column :routines, :time, :datetime
   end
 end

--- a/spec/factories/care_relationships.rb
+++ b/spec/factories/care_relationships.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :parent, factory: :user
     association :caregiver, factory: :user
     association :child
+
     status { :ongoing }
   end
 end

--- a/spec/factories/children.rb
+++ b/spec/factories/children.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :child do
     association :user
-    name { "テストちゃん" }
-    birth_date { Date.today - 1.year }
-    gender { "boy" } # 必要ならstringで保存されてるgenderに合わせて調整
+    name { Faker::Name.first_name + "ちゃん" }
+    birth_date { Faker::Date.between(from: '2020-01-01', to: Date.today) }
+    gender { Child.genders.keys.sample }
   end
 end

--- a/spec/factories/hospital.rb
+++ b/spec/factories/hospital.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :hospital do
+    association :user
+    association :child
+    name { "緊急病院" }
+    phone_number { "09012345678" }
+  end
+end

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :record do
+    association :user
+    association :child
+
+    record_type { Record.record_types.keys.sample }
+    category { Record.categories.keys.sample }
+    quantity { Faker::Number.between(from: 1, to: 5) }
+    recorded_at { Faker::Time.between(from: 2.days.ago, to: Time.current, format: :default) }
+    memo { Faker::Lorem.sentence(word_count: 5) }
+  end
+end

--- a/spec/factories/routines.rb
+++ b/spec/factories/routines.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :routine do
-    child { nil }
-    time { "MyString" }
-    task { "MyString" }
+    association :child
+    time { "09:00" }
+    task { :milk }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :user do
-    nickname { "育児パパ" }
-    email { Faker::Internet.email }
+    sequence(:email) { |n| "test#{n}@example.com" }
     password { "password123" }
     password_confirmation { "password123" }
+    nickname { Faker::Name.name }
     role { :role_parent }
   end
 end

--- a/spec/models/care_relationship_spec.rb
+++ b/spec/models/care_relationship_spec.rb
@@ -1,44 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe CareRelationship, type: :model do
-  let(:parent) { FactoryBot.create(:user) }
+  let(:parent)    { FactoryBot.create(:user) }
   let(:caregiver) { FactoryBot.create(:user) }
-  let(:child) { FactoryBot.create(:child, user: parent) }
+  let(:child)     { FactoryBot.create(:child, user: parent) }
+
+  subject do
+    described_class.new(
+      parent: parent,
+      caregiver: caregiver,
+      child: child,
+      status: "ongoing"
+    )
+  end
 
   describe 'バリデーション' do
-    it 'すべての値が存在すれば保存できること' do
-      relationship = CareRelationship.new(parent: parent, caregiver: caregiver, child: child, status: :ongoing)
-      expect(relationship).to be_valid
+    it '有効な場合は保存できる' do
+      expect(subject).to be_valid
     end
 
-    it 'parentが空だと無効' do
-      relationship = CareRelationship.new(parent: nil, caregiver: caregiver, child: child, status: :ongoing)
-      expect(relationship).to be_invalid
-      expect(relationship.errors[:parent]).to include("を入力してください")
+    it '親が存在しないと無効' do
+      subject.parent = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:parent]).to include("を入力してください")
     end
 
-    it 'caregiverが空だと無効' do
-      relationship = CareRelationship.new(parent: parent, caregiver: nil, child: child, status: :ongoing)
-      expect(relationship).to be_invalid
-      expect(relationship.errors[:caregiver]).to include("を入力してください")
+    it '保育者が存在しないと無効' do
+      subject.caregiver = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:caregiver]).to include("を入力してください")
     end
 
-    it 'childが空だと無効' do
-      relationship = CareRelationship.new(parent: parent, caregiver: caregiver, child: nil, status: :ongoing)
-      expect(relationship).to be_invalid
-      expect(relationship.errors[:child]).to include("を入力してください")
+    it '子どもが存在しないと無効' do
+      subject.child = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:child]).to include("を入力してください")
     end
 
-    it 'statusが空だと無効' do
-      relationship = CareRelationship.new(parent: parent, caregiver: caregiver, child: child, status: nil)
-      expect(relationship).to be_invalid
-      expect(relationship.errors[:status]).to include("を入力してください")
+    it 'ステータスが空だと無効' do
+      subject.status = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:status]).to include("を入力してください")
+    end
+
+    it '親と保育者が同一人物だと無効' do
+      subject.caregiver = subject.parent
+      expect(subject).to be_invalid
+      expect(subject.errors[:caregiver_id]).to include("に自分自身は指定できません")
     end
   end
 
-  describe 'enum' do
-    it 'statusがongoingかendedであること' do
-      expect(CareRelationship.statuses.keys).to include('ongoing', 'ended')
+  describe '#status_i18n' do
+    it '日本語のステータス名を返す（ongoing）' do
+      subject.status = "ongoing"
+      expect(subject.status_i18n).to eq("預かり中")
+    end
+
+    it '日本語のステータス名を返す（ended）' do
+      subject.status = "ended"
+      expect(subject.status_i18n).to eq("終了")
     end
   end
 end

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe Child, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+
+  subject do
+    described_class.new(
+      user: user,
+      name: "あかりちゃん",
+      birth_date: "2021-05-05",
+      gender: :girl
+    )
+  end
+
+  describe 'バリデーション' do
+    it 'すべての情報が正しければ有効' do
+      expect(subject).to be_valid
+    end
+
+    it 'nameが空だと無効' do
+      subject.name = ""
+      expect(subject).to be_invalid
+      expect(subject.errors[:name]).to include("を入力してください")
+    end
+
+    it 'birth_dateが空だと無効' do
+      subject.birth_date = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:birth_date]).to include("を入力してください")
+    end
+
+    it 'genderが空だと無効' do
+      subject.gender = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:gender]).to include("を入力してください")
+    end
+  end
+
+  describe '#shared_with?' do
+    let(:caregiver) { FactoryBot.create(:user) }
+    let!(:care_relationship) do
+      FactoryBot.create(:care_relationship, parent: user, caregiver: caregiver, child: subject, status: :ongoing)
+    end
+
+    it '共有中の保育者であれば true を返す' do
+      subject.save!
+      expect(subject.shared_with?(caregiver)).to be true
+    end
+
+    it '共有されていないユーザーであれば false を返す' do
+      other_user = FactoryBot.create(:user)
+      subject.save!
+      expect(subject.shared_with?(other_user)).to be false
+    end
+  end
+
+  describe '.accessible_by' do
+    let(:caregiver) { FactoryBot.create(:user) }
+    let(:child_shared) { FactoryBot.create(:child, user: user) }
+    let!(:relation) do
+      FactoryBot.create(:care_relationship, parent: user, caregiver: caregiver, child: child_shared, status: :ongoing)
+    end
+
+    it '親ユーザーの子どもが含まれる' do
+      own_child = FactoryBot.create(:child, user: caregiver)
+      result = Child.accessible_by(caregiver)
+      expect(result).to include(own_child)
+    end
+
+    it '共有中の子どもが含まれる' do
+      result = Child.accessible_by(caregiver)
+      expect(result).to include(child_shared)
+    end
+
+    it '終了済みの関係では含まれない' do
+      relation.update(status: :ended)
+      result = Child.accessible_by(caregiver)
+      expect(result).not_to include(child_shared)
+    end
+  end
+end

--- a/spec/models/hospital_spec.rb
+++ b/spec/models/hospital_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Hospital, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:child) { FactoryBot.create(:child, user: user) }
+
+  subject do
+    described_class.new(
+      user: user,
+      child: child,
+      name: "小児科クリニック",
+      phone_number: "09012345678"
+    )
+  end
+
+  describe 'バリデーション' do
+    it 'すべての情報が正しければ有効' do
+      expect(subject).to be_valid
+    end
+
+    it 'nameが空だと無効' do
+      subject.name = ""
+      expect(subject).to be_invalid
+      expect(subject.errors[:name]).to include("緊急連絡名を入力してください")
+    end
+
+    it 'phone_numberが空だと無効' do
+      subject.phone_number = ""
+      expect(subject).to be_invalid
+      expect(subject.errors[:phone_number]).to include("電話番号を入力してください")
+    end
+
+    it 'phone_numberにハイフンがあると無効' do
+      subject.phone_number = "090-1234-5678"
+      expect(subject).to be_invalid
+      expect(subject.errors[:phone_number]).to include("ハイフンなしで入力してください")
+    end
+
+    it 'phone_numberが不正な形式だと無効（11桁未満）' do
+      subject.phone_number = "031234567"
+      expect(subject).to be_invalid
+      expect(subject.errors[:phone_number]).to include("有効な電話番号を入力してください")
+    end
+
+    it 'userが紐づいていないと無効' do
+      subject.user = nil
+      expect(subject).to be_invalid
+    end
+
+    it 'childが紐づいていないと無効' do
+      subject.child = nil
+      expect(subject).to be_invalid
+    end
+  end
+end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Record, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:child) { FactoryBot.create(:child, user: user) }
+
+  subject do
+    described_class.new(
+      user: user,
+      child: child,
+      record_type: :milk,
+      category: :nutrition,
+      quantity: 1,
+      recorded_at: Time.current
+    )
+  end
+
+  describe 'バリデーション' do
+    it 'すべての情報が正しければ有効' do
+      expect(subject).to be_valid
+    end
+
+    it 'record_typeが空だと無効' do
+      subject.record_type = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:record_type]).not_to be_empty # ← メッセージ内容には依存しない
+    end
+
+    it 'categoryが空だと無効' do
+      subject.category = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:category]).not_to be_empty
+    end
+
+    it 'recorded_atが空だと無効' do
+      subject.recorded_at = nil
+      expect(subject).to be_invalid
+      expect(subject.errors.full_messages).to include(a_string_matching(/記録日時/))
+    end
+
+    it 'quantityが空だと無効' do
+      subject.quantity = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:quantity]).to include("は数値で入力してください")
+    end
+
+    it 'quantityが0以下だと無効' do
+      subject.quantity = 0
+      expect(subject).to be_invalid
+      expect(subject.errors[:quantity]).to include("は1以上を入力してください")
+    end
+
+    it 'childが紐づいていないと無効' do
+      subject.child = nil
+      expect(subject).to be_invalid
+    end
+
+    it 'userが紐づいていないと無効' do
+      subject.user = nil
+      expect(subject).to be_invalid
+    end
+  end
+end

--- a/spec/models/routine_spec.rb
+++ b/spec/models/routine_spec.rb
@@ -1,5 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe Routine, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:child) { FactoryBot.create(:child) }
+
+  subject do
+    described_class.new(
+      child: child,
+      time: "08:00",
+      task: "milk"
+    )
+  end
+
+  describe 'バリデーション' do
+    it '有効な内容で保存できる' do
+      expect(subject).to be_valid
+    end
+
+    it 'timeがないと無効' do
+      subject.time = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:time]).to include("を入力してください")
+    end
+
+    it 'taskがないと無効' do
+      subject.task = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:task]).to include("を入力してください")
+    end
+
+    it 'childが紐づいていないと無効' do
+      subject.child = nil
+      expect(subject).to be_invalid
+    end
+  end
+
+  describe '#task_label' do
+    it 'taskがmilkのとき、日本語表記を返す' do
+      subject.task = "milk"
+      expect(subject.task_label).to eq("ミルク")
+    end
+  end
+
+  describe '.task_options_for_select' do
+    it '日本語ラベルと英語キーの配列を返す' do
+      expect(Routine.task_options_for_select).to include(%W[\u30DF\u30EB\u30AF milk])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,62 +1,61 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  before do
-    @user = FactoryBot.build(:user)
+  subject do
+    described_class.new(
+      email: "test@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      nickname: "テストユーザー",
+      role: "role_parent"
+    )
   end
 
-  describe 'ユーザー新規登録' do
-    context '登録できる場合' do
-      it 'nickname, email, password, password_confirmation, role があれば登録できる' do
-        expect(@user).to be_valid
-      end
+  describe 'バリデーション' do
+    it 'すべての情報が正しければ有効' do
+      expect(subject).to be_valid
     end
 
-    context '登録できない場合' do
-      it 'nicknameが空では登録できない' do
-        @user.nickname = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
-      end
+    it 'nicknameが空だと無効' do
+      subject.nickname = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:nickname]).to include("を入力してください")
+    end
 
-      it 'emailが空では登録できない' do
-        @user.email = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
-      end
+    it 'roleが空だと無効' do
+      subject.role = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:role]).to include("を入力してください")
+    end
 
-      it '重複したemailは登録できない' do
-        @user.save
-        another_user = FactoryBot.build(:user, email: @user.email)
-        another_user.valid?
-        expect(another_user.errors.full_messages).to include("Email has already been taken")
-      end
+    it 'emailが空だと無効' do
+      subject.email = nil
+      expect(subject).to be_invalid
+    end
 
-      it 'passwordが空では登録できない' do
-        @user.password = ''
-        @user.password_confirmation = ''
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
-      end
+    it 'passwordが短すぎると無効' do
+      subject.password = subject.password_confirmation = "12345"
+      expect(subject).to be_invalid
+    end
+  end
 
-      it 'passwordが6文字未満では登録できない' do
-        @user.password = '12345'
-        @user.password_confirmation = '12345'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
-      end
+  describe '#can_access?' do
+    let(:user_parent) { FactoryBot.create(:user, role: :role_parent) }
+    let(:user_caregiver) { FactoryBot.create(:user, role: :role_caregiver) }
+    let(:child) { FactoryBot.create(:child, user: user_parent) }
 
-      it 'passwordとpassword_confirmationが一致していないと登録できない' do
-        @user.password_confirmation = 'mismatch'
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-      end
+    it '親ユーザーは自分の子どもにアクセスできる' do
+      expect(user_parent.can_access?(child)).to be true
+    end
 
-      it 'roleが空では登録できない' do
-        @user.role = nil
-        @user.valid?
-        expect(@user.errors.full_messages).to include("Role can't be blank")
-      end
+    it '保育者は共有中ならアクセスできる' do
+      FactoryBot.create(:care_relationship, parent: user_parent, caregiver: user_caregiver, child: child, status: :ongoing)
+      expect(user_caregiver.can_access?(child)).to be true
+    end
+
+    it '保育者が終了済みの場合はアクセスできない' do
+      FactoryBot.create(:care_relationship, parent: user_parent, caregiver: user_caregiver, child: child, status: :ended)
+      expect(user_caregiver.can_access?(child)).to be false
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
+  config.include Devise::Test::IntegrationHelpers, type: :request
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/requests/children_request_spec.rb
+++ b/spec/requests/children_request_spec.rb
@@ -1,26 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe "Children", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    sign_in user
+  end
 
   describe "GET /new" do
     it "returns http success" do
-      get "/children/new"
+      get new_child_path
       expect(response).to have_http_status(:success)
     end
   end
 
   describe "GET /index" do
     it "returns http success" do
-      get "/children/index"
+      get children_path
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /create" do
-    it "returns http success" do
-      get "/children/create"
-      expect(response).to have_http_status(:success)
+  describe "POST /create" do
+    it "returns http redirect" do
+      post children_path, params: {
+        child: {
+          name: "テストちゃん",
+          birth_date: "2020-01-01",
+          gender: "girl"
+        }
+      }
+      expect(response).to redirect_to(root_path) # 必要に応じて修正
     end
   end
-
 end


### PR DESCRIPTION

#What:  
- PostgreSQLマイグレーションエラー対応（`time` 型への変換時に USING 明示）  
- 病院・育児記録モーダルがエラー2回目以降に開かなくなる問題をJSで修正  
- ルーティンや育児記録でI18nの文字化けを修正し日本語表示に統一  
- モーダルフォームのエラー再表示処理をJSに統合・整理  
- 表示上の不具合や見え方（記録一覧へのカテゴリ表示など）も反映  


#Why:  
- PostgreSQL固有の型変換仕様に対応する必要があったため  
- ユーザーがエラー後に入力内容を再修正できないバグを防ぐため  
- 表示の整合性・可読性を高め、ユーザー体験を改善するため  
- 一貫したバリデーション・モーダル制御を維持しやすくするため