### PR TITLE
ユーザーエラーメッセージ作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -377,3 +377,18 @@ h4, h5 {
   // モバイル対応の影や余白も任意で
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
 }
+
+.form-errors {
+  background-color: #fff5f5; // ほんのり赤背景
+  border: 1px solid #f1c0c0; // 赤系の薄いボーダー
+  color: #c0392b; // 落ち着いた赤文字
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  margin-bottom: 20px;
+
+  p {
+    margin: 0 0 6px;
+  }
+}
+

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,6 +2,15 @@
   <div class="signup-card card shadow-sm rounded-4 p-4">
     <h2 class="signup-title text-center mb-4">アカウント登録</h2>
 
+      <!-- 🔻ここにエラーメッセージ表示 -->
+      <% if resource.errors.any? %>
+        <div class="form-errors">
+          <% resource.errors.full_messages.each do |message| %>
+            <p><%= message %></p>
+          <% end %>
+        </div>
+      <% end %>
+
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <div class="mb-3">
         <%= f.label :nickname, "ニックネーム", class: "form-label" %>
@@ -22,6 +31,7 @@
         <%= f.label :password_confirmation, "パスワード（確認）", class: "form-label" %>
         <%= f.password_field :password_confirmation, class: "form-control", autocomplete: "new-password" %>
       </div>
+
 
       <div class="d-grid">
         <%= f.submit "登録する", class: "btn btn-primary rounded-pill fw-bold" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,6 +2,19 @@
   <div class="login-card card shadow-sm rounded-4 p-4">
     <h2 class="login-title text-center mb-4">ログイン</h2>
 
+
+<% if flash[:alert].present? || resource.errors.any? %>
+  <div class="form-errors">
+    <% if flash[:alert].present? %>
+      <p><%= flash[:alert] %></p>
+    <% end %>
+
+    <% resource.errors.full_messages.each do |message| %>
+      <p><%= message %></p>
+    <% end %>
+  </div>
+<% end %>
+
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="mb-3">
         <%= f.label :email, "メールアドレス", class: "form-label" %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,11 +1,6 @@
 <% if resource.errors.any? %>
-  <div class="alert alert-danger error-messages" role="alert" data-turbo-cache="false">
-    <h5 class="fw-bold mb-2">
-      <%= I18n.t("errors.messages.not_saved",
-                count: resource.errors.count,
-                resource: resource.class.model_name.human.downcase) %>
-    </h5>
-    <ul class="mb-0 ps-3">
+  <div class="error-messages" role="alert" data-turbo-cache="false">
+    <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,22 @@
+ja:
+  devise:
+    failure:
+      invalid: "メールアドレスまたはパスワードが正しくありません"
+      not_found_in_database: "メールアドレスまたはパスワードが正しくありません"
+      already_authenticated: "すでにログインしています"
+    sessions:
+      signed_in: "ログインしました"
+      signed_out: "ログアウトしました"
+    registrations:
+      signed_up: "アカウント登録が完了しました"
+      updated: "アカウント情報を更新しました"
+      destroyed: "アカウントを削除しました"
+    passwords:
+      send_instructions: "パスワード再設定用のメールを送信しました"
+      updated: "パスワードを変更しました"
+      updated_not_active: "パスワードは変更されましたが、アカウントは有効化されていません"
+
+  errors:
+    messages:
+      not_found: "が見つかりません"
+      


### PR DESCRIPTION
#What
・ユーザー登録・編集フォームに対してバリデーションのエラーメッセージ表示機能を実装した。
・入力内容に不備があった際、Bootstrapのアラート形式でエラーを一覧表示。
・エラー発生時には、モーダルを再表示して即座に修正できるようにした。
d・evise.ja.ymlを編集して、エラーメッセージを日本語で表示するように設定。
・モーダルフォーム内の各項目（名前、メール、パスワードなど）に対して適切な日本語のバリデーションメッセージを表示。

# Why
・入力ミスに対してユーザーが何を直すべきかすぐに理解できるようにするため。
・フォームのエラーメッセージがないと、「登録できない原因がわからない」などのユーザー体験の悪化につながるため。
・英語のままではわかりづらいため、エラーメッセージを日本語化して親切なUIにするため。
・エラー発生時に画面遷移してしまうと、入力内容が失われてユーザーの手間になるため、モーダルのまま再表示する仕組みを追加。
・これらの改善により、ユーザビリティとフォーム入力の完了率を高めるため。