### PR TITLE
画像ファイルが失われたルーティンを自動削除するRakeタスクを追加

### DIFF
--- a/lib/tasks/purge_orphaned_images.rake
+++ b/lib/tasks/purge_orphaned_images.rake
@@ -1,0 +1,22 @@
+namespace :active_storage do
+  desc "Delete routines whose attached image file is missing"
+  task purge_orphaned_routines: :environment do
+    puts "Checking routines for missing images..."
+
+    deleted = 0
+
+    Routine.all.each do |routine|
+      next unless routine.image.attached?
+
+      begin
+        routine.image.blob.open {} # ファイルがあれば何もしない
+      rescue StandardError
+        puts "Deleting routine_id=#{routine.id}（画像ファイルなし）"
+        routine.destroy
+        deleted += 1
+      end
+    end
+
+    puts "削除完了：#{deleted}件"
+  end
+end


### PR DESCRIPTION
- ActiveStorageで画像ファイルが消失した状態のRoutineレコードを自動的に削除するRakeタスク（active_storage:purge_orphaned_routines）をlib/tasks配下に追加
- Renderなどの一時ストレージ環境で画像消失による500エラーを予防するための運用用バッチ
- 画像が添付されていないRoutineや、画像ファイルが存在するRoutineは影響を受けません
- 開発・検証用バッチ（本番運用時はS3など永続ストレージ利用を推奨）