### PR TITLE
通知機能検証

### DIFF
--- a/app/jobs/push_notification_job.rb
+++ b/app/jobs/push_notification_job.rb
@@ -1,15 +1,16 @@
-# app/jobs/push_notification_job.rb
 class PushNotificationJob < ApplicationJob
   queue_as :default
 
   def perform(record_id)
     record = Record.find_by(id: record_id)
-    return unless record
+    unless record
+      Rails.logger.warn "❌ PushNotificationJob: record_id=#{record_id} が見つかりません"
+      return
+    end
 
     child = record.child
     caregiver = record.user
 
-    # statusを"ongoing"に修正！
     care_relationships = CareRelationship.where(child: child, status: "ongoing")
 
     care_relationships.each do |cr|
@@ -17,22 +18,33 @@ class PushNotificationJob < ApplicationJob
       next if parent.id == caregiver.id
       next if parent.subscription_token.blank?
 
-      subscription = JSON.parse(parent.subscription_token) rescue nil
+      subscription = begin
+        JSON.parse(parent.subscription_token)
+      rescue StandardError
+        nil
+      end
       next unless subscription
 
       message = "#{child.name}に#{I18n.t("enums.record.record_type.#{record.record_type}")}の記録をつけました！！（by #{caregiver.nickname}）"
 
-      Webpush.payload_send(
-        message: JSON.generate(title: "BloomNote", body: message),
-        endpoint: subscription["endpoint"],
-        p256dh: subscription["keys"]["p256dh"],
-        auth: subscription["keys"]["auth"],
-        vapid: {
-          subject: "mailto:your-email@example.com",
-          public_key: ENV["VAPID_PUBLIC_KEY"],
-          private_key: ENV["VAPID_PRIVATE_KEY"]
-        }
-      )
+      Rails.logger.info "📢 PushNotificationJob: parent_id=#{parent.id} (#{parent.nickname}) へ通知送信を開始"
+
+      begin
+        Webpush.payload_send(
+          message: JSON.generate(title: "BloomNote", body: message),
+          endpoint: subscription["endpoint"],
+          p256dh: subscription["keys"]["p256dh"],
+          auth: subscription["keys"]["auth"],
+          vapid: {
+            subject: "mailto:your-email@example.com",
+            public_key: ENV["VAPID_PUBLIC_KEY"],
+            private_key: ENV["VAPID_PRIVATE_KEY"]
+          }
+        )
+        Rails.logger.info "✅ PushNotificationJob: parent_id=#{parent.id} (#{parent.nickname}) へ通知送信成功"
+      rescue StandardError => e
+        Rails.logger.error "❌ PushNotificationJob: parent_id=#{parent.id} への通知送信失敗 - #{e.class}: #{e.message}"
+      end
     end
   end
 end

--- a/app/jobs/push_notification_job.rb
+++ b/app/jobs/push_notification_job.rb
@@ -5,6 +5,7 @@ class PushNotificationJob < ApplicationJob
     record = Record.find_by(id: record_id)
     unless record
       Rails.logger.warn "❌ PushNotificationJob: record_id=#{record_id} が見つかりません"
+      puts "❌ PushNotificationJob: record_id=#{record_id} が見つかりません" # ターミナルにも
       return
     end
 
@@ -28,6 +29,7 @@ class PushNotificationJob < ApplicationJob
       message = "#{child.name}に#{I18n.t("enums.record.record_type.#{record.record_type}")}の記録をつけました！！（by #{caregiver.nickname}）"
 
       Rails.logger.info "📢 PushNotificationJob: parent_id=#{parent.id} (#{parent.nickname}) へ通知送信を開始"
+      puts "📢 PushNotificationJob: parent_id=#{parent.id} (#{parent.nickname}) へ通知送信を開始" # ターミナルにも
 
       begin
         Webpush.payload_send(
@@ -42,8 +44,10 @@ class PushNotificationJob < ApplicationJob
           }
         )
         Rails.logger.info "✅ PushNotificationJob: parent_id=#{parent.id} (#{parent.nickname}) へ通知送信成功"
+        puts "✅ PushNotificationJob: parent_id=#{parent.id} (#{parent.nickname}) へ通知送信成功" # ターミナルにも
       rescue StandardError => e
         Rails.logger.error "❌ PushNotificationJob: parent_id=#{parent.id} への通知送信失敗 - #{e.class}: #{e.message}"
+        puts "❌ PushNotificationJob: parent_id=#{parent.id} への通知送信失敗 - #{e.class}: #{e.message}" # ターミナルにも
       end
     end
   end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -36,28 +36,37 @@
       <i class="bi bi-list fs-3"></i>
     </button>
     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="settingsDropdown">
-      <% if user_signed_in? %>
-        <% if @children.present? %>
-          <li class="dropdown-header">子どもを切り替え</li>
-          <% @children.each do |child| %>
-            <li>
-              <%= button_to select_child_path(child), method: :patch, form: { class: "d-inline" }, class: "dropdown-item" do %>
-                <%= child.name %><%= "（共有中）" if child.shared_with?(current_user) %>
-              <% end %>
-            </li>
-          <% end %>
-          <li><hr class="dropdown-divider"></li>
+<% if user_signed_in? %>
+  <% if @children.present? %>
+    <li class="dropdown-header">子どもを切り替え</li>
+    <% @children.each do |child| %>
+      <li>
+        <%= button_to select_child_path(child), method: :patch, form: { class: "d-inline" }, class: "dropdown-item" do %>
+          <%= child.name %><%= "（共有中）" if child.shared_with?(current_user) %>
         <% end %>
-        <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addCareRelationshipModal">保育者を追加</button></li>
-        <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#careRelationshipListModal">関係者一覧</button></li>
-        <li><hr class="dropdown-divider"></li>
-        <li>
-          <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: true }, form: { class: "d-inline" }, class: "dropdown-item text-danger" %>
-        </li>
-      <% else %>
-        <li><%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %></li>
-        <li><%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %></li>
-      <% end %>
+      </li>
+    <% end %>
+    <li><hr class="dropdown-divider"></li>
+  <% end %>
+
+  <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addCareRelationshipModal">保育者を追加</button></li>
+  <li><button class="dropdown-item" data-bs-toggle="modal" data-bs-target="#careRelationshipListModal">関係者一覧</button></li>
+
+  <!-- 🔔 ここに通知許可ボタンを追加 -->
+  <li>
+    <button class="dropdown-item text-primary" id="subscribeButton">
+      通知を許可する
+    </button>
+  </li>
+
+  <li><hr class="dropdown-divider"></li>
+  <li>
+    <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: true }, form: { class: "d-inline" }, class: "dropdown-item text-danger" %>
+  </li>
+<% else %>
+  <li><%= link_to "新規登録", new_user_registration_path, class: "dropdown-item" %></li>
+  <li><%= link_to "ログイン", new_user_session_path, class: "dropdown-item" %></li>
+<% end %>
     </ul>
   </div>
 </header>

--- a/app/views/shared/_routine_modal.html.erb
+++ b/app/views/shared/_routine_modal.html.erb
@@ -34,8 +34,8 @@
               <%= f.text_area :memo, class: "form-control", rows: 2 %>
             </div>
             <div class="mb-3">
-              <%= f.label :photo, "写真（任意）" %>
-              <%= f.file_field :photo, class: "form-control" %>
+              <%# <%= f.label :photo, "写真（任意）" %> 
+              <%# <%= f.file_field :photo, class: "form-control" %> 
             </div>
             <div class="text-end">
               <%= f.submit "追加", class: "btn btn-success" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+  # ジョブを即時にターミナル内で実行（putsが即反映）
+  config.active_job.queue_adapter = :inline
 end
+

--- a/spec/requests/settings_request_spec.rb
+++ b/spec/requests/settings_request_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe "Settings", type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user # ←これでログイン状態にする
+  end
 
   describe "GET /notification" do
     it "returns http success" do
@@ -9,11 +14,10 @@ RSpec.describe "Settings", type: :request do
     end
   end
 
-  describe "GET /subscribe" do
+  describe "POST /subscribe" do
     it "returns http success" do
-      get "/settings/subscribe"
+      post "/settings/subscribe", params: { user: { subscription_token: "dummy_token" } }
       expect(response).to have_http_status(:success)
     end
   end
-
 end


### PR DESCRIPTION
# What
- 保育者が育児記録を登録したとき、親ユーザーにWeb Push通知を送信
- PushNotificationJobを作成し、記録登録時に非同期で通知処理を実行
- 通知文には「◯◯に△△の記録をつけました！！（by ◯◯）」形式を採用
- VAPID鍵（public/private）を.envに保存し、metaタグ経由でJSに渡す
- JavaScriptで通知購読・購読情報の保存処理を記述（home.js）
- 許可ボタンをドロップダウンメニューに配置（通知設定導線のUI追加）
- Service WorkerでPush受信時の通知表示を実装（service-worker.js）

# Why
- 育児記録を親と保育者でリアルタイム共有できるようにするため
- アプリを開いていなくても、親が子どもの様子を把握できる仕組みを実現したかった
- 保育者が記録を登録するたびに、親へ安心と連携を届ける体験を提供するため
- 今後の機能拡張（リマインド通知や緊急連絡通知）に備えて基盤を整備"